### PR TITLE
add target_link_library to find dolfinx

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(dolfinx_mpc "")  # The "" is needed for older CMake. Remove later.
 if (UFC_FOUND)
     target_include_directories(dolfinx_mpc PRIVATE ${UFC_INCLUDE_DIRS})
 endif()
+target_link_libraries(dolfinx_mpc PUBLIC dolfinx)
 
 
 # Delcare the library (target)


### PR DESCRIPTION
Just a suggestion: adding this prevented complaints such as `dolfinx/fem/Form.h: No such file or directory` and I figure no one would be using dolfinx_mpc without dolfinx! 