### PR TITLE
Remove xtensor

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,11 +2,11 @@ name: SonarCloud
 on:
   push:
     branches:
-      - master
+      - main
       - dokken/*
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   build:
     name: Build

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -98,12 +98,18 @@ jobs:
       - name: Install DOLFINx-MPC (Python)
         run: CXX_FLAGS="${MPC_CMAKE_CXX_FLAGS}" python3 -m pip -v install python/
 
-      - name: Run tests
-        run: |
-          python3 -m pytest python/tests -vs
-          mpirun -n 2 python3 -m pytest python/tests
-          mpirun -n 3 python3 -m pytest python/tests
-          mpirun -n 4 python3 -m pytest python/tests
+      - name: Run tests (serial)
+        run: python3 -m pytest python/tests -vs
+          
+      - name: Run tests (2 processes)
+        run: mpirun -n 2 python3 -m pytest python/tests -vs
+
+      - name: Run tests (3 processes)
+        run: mpirun -n 3 python3 -m pytest python/tests
+
+      - name: Run tests (4 processss)
+        run: mpirun -n 4 python3 -m pytest python/tests
+
       - name: Run benchmarks
         run: |
           cd python/benchmarks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ run-demos:
   stage: test
   only:
     - schedules
-    - master
+    - main
     - merge_requests
   tags:
     - docker

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Docker image can be found in the [Packages](https://github.com/jorgensd/dolfin
 
 ## Source
 
-To install the latest version (master branch), you need to install the latest release of [dolfinx](https://github.com/FEniCS/dolfinx).
+To install the latest version (main branch), you need to install the latest release of [dolfinx](https://github.com/FEniCS/dolfinx).
 Easiest way to install dolfinx is to use docker. The dolfinx docker images goes under the name [dolfinx/dolfinx](https://hub.docker.com/r/dolfinx/dolfinx)
 
 To install the `dolfinx_mpc`-library run the following code from this directory:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -90,7 +90,7 @@ set_package_properties(UFC PROPERTIES TYPE REQUIRED
   URL "https://github.com/fenics/ffcx")
 
 # Check for required package DOLFINX
-find_package(DOLFINX 0.5.1 REQUIRED)
+find_package(DOLFINX 0.5.2 REQUIRED)
 set_package_properties(DOLFINX PROPERTIES TYPE REQUIRED
     DESCRIPTION "New generation Dynamic Object-oriented Library for - FINite element computation"
     URL "https://github.com/FEniCS/dolfinx"

--- a/cpp/ContactConstraint.cpp
+++ b/cpp/ContactConstraint.cpp
@@ -400,7 +400,7 @@ mpc_data dolfinx_mpc::create_contact_slip_condition(
          gdim](const std::int32_t block, std::span<PetscScalar, 3> normal)
   {
     std::iota(dofs.begin(), dofs.end(), block * block_size);
-    for (std::size_t j = 0; j < gdim; ++j)
+    for (int j = 0; j < gdim; ++j)
       normal[j] = normal_array[dofs[j]];
     double norm = std::sqrt(normal[0] * normal[0] + normal[1] * normal[1]
                             + normal[2] * normal[2]);

--- a/cpp/ContactConstraint.cpp
+++ b/cpp/ContactConstraint.cpp
@@ -11,9 +11,6 @@
 #include <chrono>
 #include <dolfinx/geometry/BoundingBoxTree.h>
 #include <dolfinx/geometry/utils.h>
-#include <xtensor/xcomplex.hpp>
-#include <xtensor/xsort.hpp>
-#include <xtensor/xview.hpp>
 using namespace dolfinx_mpc;
 
 namespace

--- a/cpp/ContactConstraint.cpp
+++ b/cpp/ContactConstraint.cpp
@@ -453,8 +453,8 @@ mpc_data dolfinx_mpc::create_contact_slip_condition(
                               std::experimental::dextents<std::size_t, 2>>
         basis_span(basis.data(), basis_shape[0], basis_shape[1]);
     std::experimental::mdspan<
-        double, std::experimental::extents<
-                    std::size_t, std::experimental::dynamic_extent, 3>>
+        PetscScalar, std::experimental::extents<
+                         std::size_t, std::experimental::dynamic_extent, 3>>
         normal_span(normals.data(), local_slave_blocks.size(), 3);
     mpc_master_local = compute_master_contributions(
         local_rems, local_cell_collisions, normal_span, V, basis_span);

--- a/cpp/ContactConstraint.cpp
+++ b/cpp/ContactConstraint.cpp
@@ -558,9 +558,9 @@ mpc_data dolfinx_mpc::create_contact_slip_condition(
                           neighborhood_comms[0]);
   std::vector<double> slave_normals(disp.back() * 3);
   MPI_Neighbor_allgatherv(normals_send.data(), (int)normals_send.size(),
-                          dolfinx::MPI::mpi_type<PetscScalar>(),
+                          dolfinx::MPI::mpi_type<double>(),
                           slave_normals.data(), num_slaves_recv3.data(),
-                          disp3.data(), dolfinx::MPI::mpi_type<PetscScalar>(),
+                          disp3.data(), dolfinx::MPI::mpi_type<double>(),
                           neighborhood_comms[0]);
 
   // Compute off-process contributions

--- a/cpp/ContactConstraint.cpp
+++ b/cpp/ContactConstraint.cpp
@@ -177,7 +177,8 @@ mpc_data compute_master_contributions(
 /// n)|_slave_facet
 /// @param[in] local_slaves The slave dofs (local index)
 /// @param[in] local_slave_blocks The corresponding blocks for each slave
-/// @param[in] normals The normal vectors, shape (local_slaves.size(), 3)
+/// @param[in] normals The normal vectors, shape (local_slaves.size(), 3).
+/// Storage flattened row major.
 /// @param[in] imap The index map
 /// @param[in] block_size The block size of the index map
 /// @param[in] rank The rank of current process
@@ -185,10 +186,12 @@ mpc_data compute_master_contributions(
 mpc_data compute_block_contributions(
     const std::vector<std::int32_t>& local_slaves,
     const std::vector<std::int32_t>& local_slave_blocks,
-    const xt::xtensor<PetscScalar, 2>& normals,
+    std::span<const PetscScalar, 2> normals,
     const std::shared_ptr<const dolfinx::common::IndexMap> imap,
     std::int32_t block_size, int rank)
 {
+  assert(normals.size() % 3 == 0);
+  assert(normals.size() / 3 == local_slave_blocks.size());
   std::vector<std::int32_t> dofs(block_size);
   // Count number of masters for each local slave (only contributions from)
   // the same block as the actual slave dof
@@ -198,7 +201,7 @@ mpc_data compute_block_contributions(
     std::iota(dofs.begin(), dofs.end(), local_slave_blocks[i] * block_size);
     const std::int32_t local_slave = local_slaves[i];
     for (std::int32_t j = 0; j < block_size; ++j)
-      if ((dofs[j] != local_slave) && std::abs(normals(i, j)) > 1e-6)
+      if ((dofs[j] != local_slave) && std::abs(normals[3 * i + j]) > 1e-6)
         num_masters_in_cell[i]++;
   }
   std::vector<std::int32_t> masters_offsets(local_slaves.size() + 1);
@@ -223,9 +226,9 @@ mpc_data compute_block_contributions(
     const auto max_index = std::distance(dofs.begin(), local_max);
     for (std::int32_t j = 0; j < block_size; j++)
     {
-      if ((dofs[j] != local_slave) && std::abs(normals(i, j)) > 1e-6)
+      if ((dofs[j] != local_slave) && std::abs(normals[3 * i + j]) > 1e-6)
       {
-        PetscScalar coeff_j = -normals(i, j) / normals(i, max_index);
+        PetscScalar coeff_j = -normals[3 * i + j] / normals[3 * i + max_index];
         coefficients_in_cell[masters_offsets[i] + num_masters_in_cell[i]]
             = coeff_j;
         masters_in_cell[masters_offsets[i] + num_masters_in_cell[i]]
@@ -398,35 +401,36 @@ mpc_data dolfinx_mpc::create_contact_slip_condition(
   std::span<const PetscScalar> normal_array = nh->x()->array();
   const auto largest_normal_component
       = [&dofs, block_size, &normal_array,
-         gdim](const std::int32_t block,
-               xt::xtensor_fixed<PetscScalar, xt::xshape<3>>& normal)
+         gdim](const std::int32_t block, std::span<PetscScalar, 3> normal)
   {
     std::iota(dofs.begin(), dofs.end(), block * block_size);
-    for (std::int32_t j = 0; j < gdim; ++j)
-      normal(j) = normal_array[dofs[j]];
-    normal /= xt::sqrt(xt::sum(xt::norm(normal)));
-    return xt::argmax(xt::abs(normal))[0];
+    for (std::size_t j = 0; j < gdim; ++j)
+      normal[j] = normal_array[dofs[j]];
+    double norm = std::sqrt(normal[0] * normal[0] + normal[1] * normal[1]
+                            + normal[2] * normal[2]);
+    std::for_each(normal.begin(), normal.end(),
+                  [norm](auto& n) { return std::abs(n / norm); });
+    return std::distance(normal.begin(),
+                         std::max_element(normal.begin(), normal.end()));
   };
 
   // Determine which dof in local slave block is the actual slave
-
-  xt::xtensor<PetscScalar, 2> normals({local_slave_blocks.size(), 3});
-  xt::xtensor_fixed<PetscScalar, xt::xshape<3>> normal;
-  std::fill(normal.begin() + gdim, normal.end(), 0);
+  std::vector<PetscScalar> normals(3 * local_slave_blocks.size(), 0);
   assert(block_size == gdim);
   for (std::size_t i = 0; i < local_slave_blocks.size(); ++i)
   {
     const std::int32_t slave = local_slave_blocks[i];
-    const auto block = largest_normal_component(slave, normal);
+    const auto block = largest_normal_component(
+        slave, std::span<PetscScalar, 3>(std::next(normals.begin(), 3 * i), 3));
     local_slaves[i] = block_size * slave + block;
     local_rems[i] = block;
-    xt::row(normals, i) = normal;
   }
 
   // Compute local contributions to constraint using helper function
   // i.e. compute dot(u, n) on slave side
   mpc_data mpc_in_cell = compute_block_contributions(
-      local_slaves, local_slave_blocks, normals, imap, block_size, rank);
+      local_slaves, local_slave_blocks,
+      std::span(normals.data(), normals.size()), imap, block_size, rank);
 
   dolfinx::geometry::BoundingBoxTree bb_tree
       = create_boundingbox_tree(meshtags, fdim, master_marker, std::sqrt(eps2));
@@ -437,415 +441,421 @@ mpc_data dolfinx_mpc::create_contact_slip_condition(
   // Create map from slave dof blocks to a cell containing them
   std::vector<std::int32_t> slave_cells
       = dolfinx_mpc::create_block_to_cell_map(*V, local_slave_blocks);
-  xt::xtensor<double, 2> slave_coordinates
-      = xt::transpose(dolfinx_mpc::tabulate_dof_coordinates(
-          *V, local_slave_blocks, slave_cells));
+  std::vector<double> slave_coordinates;
   {
-    std::vector<std::int32_t> local_cell_collisions
-        = dolfinx_mpc::find_local_collisions(*mesh, bb_tree, slave_coordinates,
-                                             eps2);
-    xt::xtensor<double, 3> tabulated_basis_values
-        = dolfinx_mpc::evaluate_basis_functions(*V, slave_coordinates,
-                                                local_cell_collisions);
-
-    mpc_master_local = compute_master_contributions(
-        local_rems, local_cell_collisions, normals, V, tabulated_basis_values);
+    auto [coords, shape] = dolfinx_mpc::tabulate_dof_coordinates(
+        *V, local_slave_blocks, slave_cells);
+    slave_coordinates.resize(shape[0] * shape[1]);
   }
-  // Find slave indices were contributions are not found on the process
-  std::vector<std::int32_t>& l_offsets = mpc_master_local.offsets;
-  std::vector<std::int32_t> slave_indices_remote;
-  slave_indices_remote.reserve(local_rems.size());
-  for (std::size_t i = 0; i < local_rems.size(); i++)
+  std::vector<std::int32_t> local_cell_collisions
+      = dolfinx_mpc::find_local_collisions(*mesh, bb_tree, slave_coordinates,
+                                           eps2);
+  xt::xtensor<double, 3> tabulated_basis_values
+      = dolfinx_mpc::evaluate_basis_functions(*V, slave_coordinates,
+                                              local_cell_collisions);
+
+  mpc_master_local = compute_master_contributions(
+      local_rems, local_cell_collisions, normals, V, tabulated_basis_values);
+}
+// Find slave indices were contributions are not found on the process
+std::vector<std::int32_t>& l_offsets = mpc_master_local.offsets;
+std::vector<std::int32_t> slave_indices_remote;
+slave_indices_remote.reserve(local_rems.size());
+for (std::size_t i = 0; i < local_rems.size(); i++)
+{
+  if (l_offsets[i + 1] - l_offsets[i] == 0)
+    slave_indices_remote.push_back((int)i);
+}
+
+// Structure storing mpc arrays mpc_local
+mpc_local = concatenate(mpc_in_cell, mpc_master_local);
+
+// If serial, we gather the resulting mpc data as one constraint
+if (int mpi_size = dolfinx::MPI::size(comm); mpi_size == 1)
+{
+
+  if (!slave_indices_remote.empty())
   {
-    if (l_offsets[i + 1] - l_offsets[i] == 0)
-      slave_indices_remote.push_back((int)i);
+    throw std::runtime_error(
+        "No masters found on contact surface (when executed in serial). "
+        "Please make sure that the surfaces are in contact, or increase the "
+        "tolerance eps2.");
   }
+  // Serial assumptions
+  mpc_local.slaves = local_slaves;
+  return mpc_local;
+}
 
-  // Structure storing mpc arrays mpc_local
-  mpc_local = concatenate(mpc_in_cell, mpc_master_local);
+// Create slave_dofs->master facets and master->slave dofs neighborhood comms
+const bool has_slave = !local_slave_blocks.empty();
+std::array<MPI_Comm, 2> neighborhood_comms
+    = create_neighborhood_comms(meshtags, has_slave, master_marker);
 
-  // If serial, we gather the resulting mpc data as one constraint
-  if (int mpi_size = dolfinx::MPI::size(comm); mpi_size == 1)
+// Get the  slave->master recv from and send to ranks
+int indegree(-1);
+int outdegree(-2);
+int weighted(-1);
+MPI_Dist_graph_neighbors_count(neighborhood_comms[0], &indegree, &outdegree,
+                               &weighted);
+
+// Convert slaves missing master contributions to global index
+// and prepare data (coordinates and normals) to send to other procs
+xt::xtensor<double, 2> coordinates_send({slave_indices_remote.size(), 3});
+xt::xtensor<PetscScalar, 2> normals_send({slave_indices_remote.size(), 3});
+std::vector<std::int32_t> send_rems(slave_indices_remote.size());
+for (std::size_t i = 0; i < slave_indices_remote.size(); ++i)
+{
+  const std::int32_t slave_idx = slave_indices_remote[i];
+  send_rems[i] = local_rems[slave_idx];
+  xt::row(coordinates_send, i) = xt::row(slave_coordinates, slave_idx);
+  xt::row(normals_send, i) = xt::row(normals, slave_idx);
+}
+
+// Figure out how much data to receive from each neighbor
+const std::size_t out_collision_slaves = slave_indices_remote.size();
+std::vector<std::int32_t> num_slaves_recv(indegree + 1);
+MPI_Neighbor_allgather(&out_collision_slaves, 1,
+                       dolfinx::MPI::mpi_type<std::int32_t>(),
+                       num_slaves_recv.data(), 1,
+                       dolfinx::MPI::mpi_type<std::int32_t>(),
+                       neighborhood_comms[0]);
+num_slaves_recv.pop_back();
+
+// Compute displacements for data to receive
+std::vector<int> disp(indegree + 1, 0);
+std::partial_sum(num_slaves_recv.begin(), num_slaves_recv.end(),
+                 disp.begin() + 1);
+
+// Send data to neighbors and receive data
+std::vector<std::int32_t> recv_rems(disp.back());
+MPI_Neighbor_allgatherv(send_rems.data(), (int)send_rems.size(),
+                        dolfinx::MPI::mpi_type<std::int32_t>(),
+                        recv_rems.data(), num_slaves_recv.data(), disp.data(),
+                        dolfinx::MPI::mpi_type<std::int32_t>(),
+                        neighborhood_comms[0]);
+
+// Multiply recv size by three to accommodate vector coordinates and
+// function data
+std::vector<std::int32_t> num_slaves_recv3;
+num_slaves_recv3.reserve(indegree);
+std::transform(num_slaves_recv.begin(), num_slaves_recv.end(),
+               std::back_inserter(num_slaves_recv3),
+               [](std::int32_t num_slaves) { return 3 * num_slaves; });
+std::vector<int> disp3(indegree + 1, 0);
+std::partial_sum(num_slaves_recv3.begin(), num_slaves_recv3.end(),
+                 disp3.begin() + 1);
+
+// Send slave normal and coordinate to neighbors
+xt::xtensor<double, 2> recv_coords({std::size_t(disp.back()), 3});
+MPI_Neighbor_allgatherv(coordinates_send.data(), (int)coordinates_send.size(),
+                        dolfinx::MPI::mpi_type<double>(), recv_coords.data(),
+                        num_slaves_recv3.data(), disp3.data(),
+                        dolfinx::MPI::mpi_type<double>(),
+                        neighborhood_comms[0]);
+xt::xtensor<PetscScalar, 2> slave_normals({std::size_t(disp.back()), 3});
+MPI_Neighbor_allgatherv(normals_send.data(), (int)normals_send.size(),
+                        dolfinx::MPI::mpi_type<PetscScalar>(),
+                        slave_normals.data(), num_slaves_recv3.data(),
+                        disp3.data(), dolfinx::MPI::mpi_type<PetscScalar>(),
+                        neighborhood_comms[0]);
+
+// Compute off-process contributions
+mpc_data remote_data;
+{
+  std::vector<std::int32_t> remote_cell_collisions
+      = dolfinx_mpc::find_local_collisions(*mesh, bb_tree, recv_coords, eps2);
+  xt::xtensor<double, 3> recv_tabulated_basis_values
+      = dolfinx_mpc::evaluate_basis_functions(*V, recv_coords,
+                                              remote_cell_collisions);
+
+  remote_data = compute_master_contributions(recv_rems, remote_cell_collisions,
+                                             slave_normals, V,
+                                             recv_tabulated_basis_values);
+}
+
+// Get info about reverse communicator
+auto [src_ranks_rev, dest_ranks_rev]
+    = dolfinx_mpc::compute_neighborhood(neighborhood_comms[1]);
+const std::size_t indegree_rev = src_ranks_rev.size();
+
+// Count number of masters found on the process and convert the offsets
+// to be per process
+std::vector<std::int32_t> num_collision_masters(indegree + 1, 0);
+std::vector<int> num_out_offsets;
+num_out_offsets.reserve(indegree);
+std::transform(num_slaves_recv.begin(), num_slaves_recv.end(),
+               std::back_inserter(num_out_offsets),
+               [](std::int32_t num_slaves) { return num_slaves + 1; });
+const std::int32_t num_offsets
+    = std::accumulate(num_out_offsets.begin(), num_out_offsets.end(), 0);
+std::vector<std::int32_t> offsets_remote(num_offsets);
+std::int32_t counter = 0;
+for (std::int32_t i = 0; i < indegree; ++i)
+{
+  const std::int32_t first_pos = disp[i];
+  const std::int32_t first_offset = remote_data.offsets[first_pos];
+  num_collision_masters[i] += remote_data.offsets[disp[i + 1]] - first_offset;
+  offsets_remote[first_pos + counter++] = 0;
+  for (std::int32_t j = first_pos; j < disp[i + 1]; ++j)
+    offsets_remote[j + counter] = remote_data.offsets[j + 1] - first_offset;
+}
+
+// Communicate number of incoming masters to each process after collision
+// detection
+std::vector<int> inc_num_collision_masters(indegree_rev + 1);
+MPI_Neighbor_alltoall(num_collision_masters.data(), 1, MPI_INT,
+                      inc_num_collision_masters.data(), 1, MPI_INT,
+                      neighborhood_comms[1]);
+inc_num_collision_masters.pop_back();
+num_collision_masters.pop_back();
+
+// Create displacement vector for masters and coefficients
+std::vector<int> disp_inc_masters(indegree_rev + 1, 0);
+std::partial_sum(inc_num_collision_masters.begin(),
+                 inc_num_collision_masters.end(), disp_inc_masters.begin() + 1);
+
+// Compute send offsets for masters and coefficients
+std::vector<int> send_disp_masters(indegree + 1, 0);
+std::partial_sum(num_collision_masters.begin(), num_collision_masters.end(),
+                 send_disp_masters.begin() + 1);
+
+// Create displacement vector for incoming offsets
+std::vector<int> inc_disp_offsets(indegree_rev + 1);
+std::vector<int> num_inc_offsets(indegree_rev,
+                                 (int)slave_indices_remote.size() + 1);
+std::partial_sum(num_inc_offsets.begin(), num_inc_offsets.end(),
+                 inc_disp_offsets.begin() + 1);
+
+// Compute send offsets for master offsets
+std::vector<int> send_disp_offsets(indegree + 1, 0);
+
+std::partial_sum(num_out_offsets.begin(), num_out_offsets.end(),
+                 send_disp_offsets.begin() + 1);
+
+// Get offsets for master dofs from remote process
+std::vector<MPI_Request> requests(4);
+std::vector<std::int32_t> remote_colliding_offsets(inc_disp_offsets.back());
+MPI_Ineighbor_alltoallv(offsets_remote.data(), num_out_offsets.data(),
+                        send_disp_offsets.data(),
+                        dolfinx::MPI::mpi_type<std::int32_t>(),
+                        remote_colliding_offsets.data(), num_inc_offsets.data(),
+                        inc_disp_offsets.data(),
+                        dolfinx::MPI::mpi_type<std::int32_t>(),
+                        neighborhood_comms[1], &requests[0]);
+// Receive colliding masters and relevant data from other processor
+std::vector<std::int64_t> remote_colliding_masters(disp_inc_masters.back());
+MPI_Ineighbor_alltoallv(remote_data.masters.data(),
+                        num_collision_masters.data(), send_disp_masters.data(),
+                        dolfinx::MPI::mpi_type<std::int64_t>(),
+                        remote_colliding_masters.data(),
+                        inc_num_collision_masters.data(),
+                        disp_inc_masters.data(),
+                        dolfinx::MPI::mpi_type<std::int64_t>(),
+                        neighborhood_comms[1], &requests[1]);
+std::vector<PetscScalar> remote_colliding_coeffs(disp_inc_masters.back());
+MPI_Ineighbor_alltoallv(remote_data.coeffs.data(), num_collision_masters.data(),
+                        send_disp_masters.data(),
+                        dolfinx::MPI::mpi_type<PetscScalar>(),
+                        remote_colliding_coeffs.data(),
+                        inc_num_collision_masters.data(),
+                        disp_inc_masters.data(),
+                        dolfinx::MPI::mpi_type<PetscScalar>(),
+                        neighborhood_comms[1], &requests[2]);
+std::vector<std::int32_t> remote_colliding_owners(disp_inc_masters.back());
+MPI_Ineighbor_alltoallv(remote_data.owners.data(), num_collision_masters.data(),
+                        send_disp_masters.data(),
+                        dolfinx::MPI::mpi_type<std::int32_t>(),
+                        remote_colliding_owners.data(),
+                        inc_num_collision_masters.data(),
+                        disp_inc_masters.data(),
+                        dolfinx::MPI::mpi_type<std::int32_t>(),
+                        neighborhood_comms[1], &requests[3]);
+
+// Wait for offsets to be sent
+std::vector<MPI_Status> status(4);
+MPI_Wait(&requests[0], &status[0]);
+
+std::vector<bool> slave_found(slave_indices_remote.size(), false);
+std::vector<std::int32_t> num_inc_masters(slave_indices_remote.size());
+// Iterate through the processors and find one set of inputs per slave that
+// was sent to the other processes
+for (std::size_t i = 0; i < src_ranks_rev.size(); ++i)
+{
+  [[maybe_unused]] const std::int32_t num_offsets_on_proc
+      = inc_disp_offsets[i + 1] - inc_disp_offsets[i];
+  assert(num_offsets_on_proc == std::int32_t(slave_indices_remote.size()) + 1);
+  for (std::size_t c = 0; c < slave_indices_remote.size(); c++)
+
   {
-
-    if (!slave_indices_remote.empty())
+    const std::int32_t slave_min
+        = remote_colliding_offsets[inc_disp_offsets[i] + c];
+    const std::int32_t slave_max
+        = remote_colliding_offsets[inc_disp_offsets[i] + c + 1];
+    if (const std::int32_t num_inc = slave_max - slave_min;
+        !(slave_found[c]) && (num_inc > 0))
     {
-      throw std::runtime_error(
-          "No masters found on contact surface (when executed in serial). "
-          "Please make sure that the surfaces are in contact, or increase the "
-          "tolerance eps2.");
-    }
-    // Serial assumptions
-    mpc_local.slaves = local_slaves;
-    return mpc_local;
-  }
-
-  // Create slave_dofs->master facets and master->slave dofs neighborhood comms
-  const bool has_slave = !local_slave_blocks.empty();
-  std::array<MPI_Comm, 2> neighborhood_comms
-      = create_neighborhood_comms(meshtags, has_slave, master_marker);
-
-  // Get the  slave->master recv from and send to ranks
-  int indegree(-1);
-  int outdegree(-2);
-  int weighted(-1);
-  MPI_Dist_graph_neighbors_count(neighborhood_comms[0], &indegree, &outdegree,
-                                 &weighted);
-
-  // Convert slaves missing master contributions to global index
-  // and prepare data (coordinates and normals) to send to other procs
-  xt::xtensor<double, 2> coordinates_send({slave_indices_remote.size(), 3});
-  xt::xtensor<PetscScalar, 2> normals_send({slave_indices_remote.size(), 3});
-  std::vector<std::int32_t> send_rems(slave_indices_remote.size());
-  for (std::size_t i = 0; i < slave_indices_remote.size(); ++i)
-  {
-    const std::int32_t slave_idx = slave_indices_remote[i];
-    send_rems[i] = local_rems[slave_idx];
-    xt::row(coordinates_send, i) = xt::row(slave_coordinates, slave_idx);
-    xt::row(normals_send, i) = xt::row(normals, slave_idx);
-  }
-
-  // Figure out how much data to receive from each neighbor
-  const std::size_t out_collision_slaves = slave_indices_remote.size();
-  std::vector<std::int32_t> num_slaves_recv(indegree + 1);
-  MPI_Neighbor_allgather(
-      &out_collision_slaves, 1, dolfinx::MPI::mpi_type<std::int32_t>(),
-      num_slaves_recv.data(), 1, dolfinx::MPI::mpi_type<std::int32_t>(),
-      neighborhood_comms[0]);
-  num_slaves_recv.pop_back();
-
-  // Compute displacements for data to receive
-  std::vector<int> disp(indegree + 1, 0);
-  std::partial_sum(num_slaves_recv.begin(), num_slaves_recv.end(),
-                   disp.begin() + 1);
-
-  // Send data to neighbors and receive data
-  std::vector<std::int32_t> recv_rems(disp.back());
-  MPI_Neighbor_allgatherv(send_rems.data(), (int)send_rems.size(),
-                          dolfinx::MPI::mpi_type<std::int32_t>(),
-                          recv_rems.data(), num_slaves_recv.data(), disp.data(),
-                          dolfinx::MPI::mpi_type<std::int32_t>(),
-                          neighborhood_comms[0]);
-
-  // Multiply recv size by three to accommodate vector coordinates and
-  // function data
-  std::vector<std::int32_t> num_slaves_recv3;
-  num_slaves_recv3.reserve(indegree);
-  std::transform(num_slaves_recv.begin(), num_slaves_recv.end(),
-                 std::back_inserter(num_slaves_recv3),
-                 [](std::int32_t num_slaves) { return 3 * num_slaves; });
-  std::vector<int> disp3(indegree + 1, 0);
-  std::partial_sum(num_slaves_recv3.begin(), num_slaves_recv3.end(),
-                   disp3.begin() + 1);
-
-  // Send slave normal and coordinate to neighbors
-  xt::xtensor<double, 2> recv_coords({std::size_t(disp.back()), 3});
-  MPI_Neighbor_allgatherv(coordinates_send.data(), (int)coordinates_send.size(),
-                          dolfinx::MPI::mpi_type<double>(), recv_coords.data(),
-                          num_slaves_recv3.data(), disp3.data(),
-                          dolfinx::MPI::mpi_type<double>(),
-                          neighborhood_comms[0]);
-  xt::xtensor<PetscScalar, 2> slave_normals({std::size_t(disp.back()), 3});
-  MPI_Neighbor_allgatherv(normals_send.data(), (int)normals_send.size(),
-                          dolfinx::MPI::mpi_type<PetscScalar>(),
-                          slave_normals.data(), num_slaves_recv3.data(),
-                          disp3.data(), dolfinx::MPI::mpi_type<PetscScalar>(),
-                          neighborhood_comms[0]);
-
-  // Compute off-process contributions
-  mpc_data remote_data;
-  {
-    std::vector<std::int32_t> remote_cell_collisions
-        = dolfinx_mpc::find_local_collisions(*mesh, bb_tree, recv_coords, eps2);
-    xt::xtensor<double, 3> recv_tabulated_basis_values
-        = dolfinx_mpc::evaluate_basis_functions(*V, recv_coords,
-                                                remote_cell_collisions);
-
-    remote_data = compute_master_contributions(
-        recv_rems, remote_cell_collisions, slave_normals, V,
-        recv_tabulated_basis_values);
-  }
-
-  // Get info about reverse communicator
-  auto [src_ranks_rev, dest_ranks_rev]
-      = dolfinx_mpc::compute_neighborhood(neighborhood_comms[1]);
-  const std::size_t indegree_rev = src_ranks_rev.size();
-
-  // Count number of masters found on the process and convert the offsets
-  // to be per process
-  std::vector<std::int32_t> num_collision_masters(indegree + 1, 0);
-  std::vector<int> num_out_offsets;
-  num_out_offsets.reserve(indegree);
-  std::transform(num_slaves_recv.begin(), num_slaves_recv.end(),
-                 std::back_inserter(num_out_offsets),
-                 [](std::int32_t num_slaves) { return num_slaves + 1; });
-  const std::int32_t num_offsets
-      = std::accumulate(num_out_offsets.begin(), num_out_offsets.end(), 0);
-  std::vector<std::int32_t> offsets_remote(num_offsets);
-  std::int32_t counter = 0;
-  for (std::int32_t i = 0; i < indegree; ++i)
-  {
-    const std::int32_t first_pos = disp[i];
-    const std::int32_t first_offset = remote_data.offsets[first_pos];
-    num_collision_masters[i] += remote_data.offsets[disp[i + 1]] - first_offset;
-    offsets_remote[first_pos + counter++] = 0;
-    for (std::int32_t j = first_pos; j < disp[i + 1]; ++j)
-      offsets_remote[j + counter] = remote_data.offsets[j + 1] - first_offset;
-  }
-
-  // Communicate number of incoming masters to each process after collision
-  // detection
-  std::vector<int> inc_num_collision_masters(indegree_rev + 1);
-  MPI_Neighbor_alltoall(num_collision_masters.data(), 1, MPI_INT,
-                        inc_num_collision_masters.data(), 1, MPI_INT,
-                        neighborhood_comms[1]);
-  inc_num_collision_masters.pop_back();
-  num_collision_masters.pop_back();
-
-  // Create displacement vector for masters and coefficients
-  std::vector<int> disp_inc_masters(indegree_rev + 1, 0);
-  std::partial_sum(inc_num_collision_masters.begin(),
-                   inc_num_collision_masters.end(),
-                   disp_inc_masters.begin() + 1);
-
-  // Compute send offsets for masters and coefficients
-  std::vector<int> send_disp_masters(indegree + 1, 0);
-  std::partial_sum(num_collision_masters.begin(), num_collision_masters.end(),
-                   send_disp_masters.begin() + 1);
-
-  // Create displacement vector for incoming offsets
-  std::vector<int> inc_disp_offsets(indegree_rev + 1);
-  std::vector<int> num_inc_offsets(indegree_rev,
-                                   (int)slave_indices_remote.size() + 1);
-  std::partial_sum(num_inc_offsets.begin(), num_inc_offsets.end(),
-                   inc_disp_offsets.begin() + 1);
-
-  // Compute send offsets for master offsets
-  std::vector<int> send_disp_offsets(indegree + 1, 0);
-
-  std::partial_sum(num_out_offsets.begin(), num_out_offsets.end(),
-                   send_disp_offsets.begin() + 1);
-
-  // Get offsets for master dofs from remote process
-  std::vector<MPI_Request> requests(4);
-  std::vector<std::int32_t> remote_colliding_offsets(inc_disp_offsets.back());
-  MPI_Ineighbor_alltoallv(
-      offsets_remote.data(), num_out_offsets.data(), send_disp_offsets.data(),
-      dolfinx::MPI::mpi_type<std::int32_t>(), remote_colliding_offsets.data(),
-      num_inc_offsets.data(), inc_disp_offsets.data(),
-      dolfinx::MPI::mpi_type<std::int32_t>(), neighborhood_comms[1],
-      &requests[0]);
-  // Receive colliding masters and relevant data from other processor
-  std::vector<std::int64_t> remote_colliding_masters(disp_inc_masters.back());
-  MPI_Ineighbor_alltoallv(
-      remote_data.masters.data(), num_collision_masters.data(),
-      send_disp_masters.data(), dolfinx::MPI::mpi_type<std::int64_t>(),
-      remote_colliding_masters.data(), inc_num_collision_masters.data(),
-      disp_inc_masters.data(), dolfinx::MPI::mpi_type<std::int64_t>(),
-      neighborhood_comms[1], &requests[1]);
-  std::vector<PetscScalar> remote_colliding_coeffs(disp_inc_masters.back());
-  MPI_Ineighbor_alltoallv(
-      remote_data.coeffs.data(), num_collision_masters.data(),
-      send_disp_masters.data(), dolfinx::MPI::mpi_type<PetscScalar>(),
-      remote_colliding_coeffs.data(), inc_num_collision_masters.data(),
-      disp_inc_masters.data(), dolfinx::MPI::mpi_type<PetscScalar>(),
-      neighborhood_comms[1], &requests[2]);
-  std::vector<std::int32_t> remote_colliding_owners(disp_inc_masters.back());
-  MPI_Ineighbor_alltoallv(
-      remote_data.owners.data(), num_collision_masters.data(),
-      send_disp_masters.data(), dolfinx::MPI::mpi_type<std::int32_t>(),
-      remote_colliding_owners.data(), inc_num_collision_masters.data(),
-      disp_inc_masters.data(), dolfinx::MPI::mpi_type<std::int32_t>(),
-      neighborhood_comms[1], &requests[3]);
-
-  // Wait for offsets to be sent
-  std::vector<MPI_Status> status(4);
-  MPI_Wait(&requests[0], &status[0]);
-
-  std::vector<bool> slave_found(slave_indices_remote.size(), false);
-  std::vector<std::int32_t> num_inc_masters(slave_indices_remote.size());
-  // Iterate through the processors and find one set of inputs per slave that
-  // was sent to the other processes
-  for (std::size_t i = 0; i < src_ranks_rev.size(); ++i)
-  {
-    [[maybe_unused]] const std::int32_t num_offsets_on_proc
-        = inc_disp_offsets[i + 1] - inc_disp_offsets[i];
-    assert(num_offsets_on_proc
-           == std::int32_t(slave_indices_remote.size()) + 1);
-    for (std::size_t c = 0; c < slave_indices_remote.size(); c++)
-
-    {
-      const std::int32_t slave_min
-          = remote_colliding_offsets[inc_disp_offsets[i] + c];
-      const std::int32_t slave_max
-          = remote_colliding_offsets[inc_disp_offsets[i] + c + 1];
-      if (const std::int32_t num_inc = slave_max - slave_min;
-          !(slave_found[c]) && (num_inc > 0))
-      {
-        slave_found[c] = true;
-        num_inc_masters[c] = num_inc;
-      }
-    }
-  }
-  if (auto not_found = std::find(slave_found.begin(), slave_found.end(), false);
-      not_found != slave_found.end())
-  {
-    std::runtime_error(
-        "Masters not found on contact surface with local search or remote "
-        "search. Consider running the code in serial to make sure that one can "
-        "detect the contact surface, or increase eps2.");
-  }
-
-  /// Wait for all communication to finish
-  MPI_Waitall(4, requests.data(), status.data());
-
-  // Move the masters, coeffs and owners from the input adjacency list
-  // to one where each node corresponds to an entry in slave_indices_remote
-  std::vector<std::int32_t> offproc_offsets(slave_indices_remote.size() + 1, 0);
-  std::partial_sum(num_inc_masters.begin(), num_inc_masters.end(),
-                   offproc_offsets.begin() + 1);
-  std::vector<std::int64_t> offproc_masters(offproc_offsets.back());
-  std::vector<PetscScalar> offproc_coeffs(offproc_offsets.back());
-  std::vector<std::int32_t> offproc_owners(offproc_offsets.back());
-
-  std::fill(slave_found.begin(), slave_found.end(), false);
-  for (std::size_t i = 0; i < src_ranks_rev.size(); ++i)
-  {
-    const std::int32_t proc_start = disp_inc_masters[i];
-    [[maybe_unused]] const std::int32_t num_offsets_on_proc
-        = inc_disp_offsets[i + 1] - inc_disp_offsets[i];
-    assert(num_offsets_on_proc
-           == std::int32_t(slave_indices_remote.size()) + 1);
-    for (std::size_t c = 0; c < slave_indices_remote.size(); c++)
-    {
-      assert(std::int32_t(remote_colliding_offsets.size())
-             > std::int32_t(inc_disp_offsets[i] + c));
-      assert(std::int32_t(remote_colliding_offsets.size())
-             > std::int32_t(inc_disp_offsets[i] + c + 1));
-      assert(std::int32_t(inc_disp_offsets[i] + c) < inc_disp_offsets[i + 1]);
-      const std::int32_t slave_min
-          = remote_colliding_offsets[inc_disp_offsets[i] + c];
-      const std::int32_t slave_max
-          = remote_colliding_offsets[inc_disp_offsets[i] + c + 1];
-
-      assert(c < slave_found.size());
-      if (!(slave_found[c]) && (slave_max - slave_min > 0))
-      {
-        slave_found[c] = true;
-        std::copy(remote_colliding_masters.begin() + proc_start + slave_min,
-                  remote_colliding_masters.begin() + proc_start + slave_max,
-                  offproc_masters.begin() + offproc_offsets[c]);
-
-        std::copy(remote_colliding_coeffs.begin() + proc_start + slave_min,
-                  remote_colliding_coeffs.begin() + proc_start + slave_max,
-                  offproc_coeffs.begin() + offproc_offsets[c]);
-
-        std::copy(remote_colliding_owners.begin() + proc_start + slave_min,
-                  remote_colliding_owners.begin() + proc_start + slave_max,
-                  offproc_owners.begin() + offproc_offsets[c]);
-      }
+      slave_found[c] = true;
+      num_inc_masters[c] = num_inc;
     }
   }
-  // Merge local data with incoming data
-  // First count number of local masters
-  std::vector<std::int32_t>& masters_offsets = mpc_local.offsets;
-  std::vector<std::int64_t>& masters_out = mpc_local.masters;
-  std::vector<PetscScalar>& coefficients_out = mpc_local.coeffs;
-  std::vector<std::int32_t>& owners_out = mpc_local.owners;
+}
+if (auto not_found = std::find(slave_found.begin(), slave_found.end(), false);
+    not_found != slave_found.end())
+{
+  std::runtime_error(
+      "Masters not found on contact surface with local search or remote "
+      "search. Consider running the code in serial to make sure that one can "
+      "detect the contact surface, or increase eps2.");
+}
 
-  std::vector<std::int32_t> num_masters_per_slave(local_slaves.size(), 0);
+/// Wait for all communication to finish
+MPI_Waitall(4, requests.data(), status.data());
+
+// Move the masters, coeffs and owners from the input adjacency list
+// to one where each node corresponds to an entry in slave_indices_remote
+std::vector<std::int32_t> offproc_offsets(slave_indices_remote.size() + 1, 0);
+std::partial_sum(num_inc_masters.begin(), num_inc_masters.end(),
+                 offproc_offsets.begin() + 1);
+std::vector<std::int64_t> offproc_masters(offproc_offsets.back());
+std::vector<PetscScalar> offproc_coeffs(offproc_offsets.back());
+std::vector<std::int32_t> offproc_owners(offproc_offsets.back());
+
+std::fill(slave_found.begin(), slave_found.end(), false);
+for (std::size_t i = 0; i < src_ranks_rev.size(); ++i)
+{
+  const std::int32_t proc_start = disp_inc_masters[i];
+  [[maybe_unused]] const std::int32_t num_offsets_on_proc
+      = inc_disp_offsets[i + 1] - inc_disp_offsets[i];
+  assert(num_offsets_on_proc == std::int32_t(slave_indices_remote.size()) + 1);
+  for (std::size_t c = 0; c < slave_indices_remote.size(); c++)
+  {
+    assert(std::int32_t(remote_colliding_offsets.size())
+           > std::int32_t(inc_disp_offsets[i] + c));
+    assert(std::int32_t(remote_colliding_offsets.size())
+           > std::int32_t(inc_disp_offsets[i] + c + 1));
+    assert(std::int32_t(inc_disp_offsets[i] + c) < inc_disp_offsets[i + 1]);
+    const std::int32_t slave_min
+        = remote_colliding_offsets[inc_disp_offsets[i] + c];
+    const std::int32_t slave_max
+        = remote_colliding_offsets[inc_disp_offsets[i] + c + 1];
+
+    assert(c < slave_found.size());
+    if (!(slave_found[c]) && (slave_max - slave_min > 0))
+    {
+      slave_found[c] = true;
+      std::copy(remote_colliding_masters.begin() + proc_start + slave_min,
+                remote_colliding_masters.begin() + proc_start + slave_max,
+                offproc_masters.begin() + offproc_offsets[c]);
+
+      std::copy(remote_colliding_coeffs.begin() + proc_start + slave_min,
+                remote_colliding_coeffs.begin() + proc_start + slave_max,
+                offproc_coeffs.begin() + offproc_offsets[c]);
+
+      std::copy(remote_colliding_owners.begin() + proc_start + slave_min,
+                remote_colliding_owners.begin() + proc_start + slave_max,
+                offproc_owners.begin() + offproc_offsets[c]);
+    }
+  }
+}
+// Merge local data with incoming data
+// First count number of local masters
+std::vector<std::int32_t>& masters_offsets = mpc_local.offsets;
+std::vector<std::int64_t>& masters_out = mpc_local.masters;
+std::vector<PetscScalar>& coefficients_out = mpc_local.coeffs;
+std::vector<std::int32_t>& owners_out = mpc_local.owners;
+
+std::vector<std::int32_t> num_masters_per_slave(local_slaves.size(), 0);
+for (std::size_t i = 0; i < local_slaves.size(); ++i)
+  num_masters_per_slave[i] += masters_offsets[i + 1] - masters_offsets[i];
+// Then add the remote masters
+for (std::size_t i = 0; i < slave_indices_remote.size(); ++i)
+  num_masters_per_slave[slave_indices_remote[i]]
+      += offproc_offsets[i + 1] - offproc_offsets[i];
+
+// Create new offset array
+std::vector<std::int32_t> local_offsets(local_slaves.size() + 1, 0);
+std::partial_sum(num_masters_per_slave.begin(), num_masters_per_slave.end(),
+                 local_offsets.begin() + 1);
+
+// Reuse num_masters_per_slave for input indices
+std::vector<std::int64_t> local_masters(local_offsets.back());
+std::vector<std::int32_t> local_owners(local_offsets.back());
+std::vector<PetscScalar> local_coeffs(local_offsets.back());
+
+// Insert local contributions
+{
+  std::vector<std::int32_t> loc_pos(local_slaves.size(), 0);
   for (std::size_t i = 0; i < local_slaves.size(); ++i)
-    num_masters_per_slave[i] += masters_offsets[i + 1] - masters_offsets[i];
-  // Then add the remote masters
-  for (std::size_t i = 0; i < slave_indices_remote.size(); ++i)
-    num_masters_per_slave[slave_indices_remote[i]]
-        += offproc_offsets[i + 1] - offproc_offsets[i];
-
-  // Create new offset array
-  std::vector<std::int32_t> local_offsets(local_slaves.size() + 1, 0);
-  std::partial_sum(num_masters_per_slave.begin(), num_masters_per_slave.end(),
-                   local_offsets.begin() + 1);
-
-  // Reuse num_masters_per_slave for input indices
-  std::vector<std::int64_t> local_masters(local_offsets.back());
-  std::vector<std::int32_t> local_owners(local_offsets.back());
-  std::vector<PetscScalar> local_coeffs(local_offsets.back());
-
-  // Insert local contributions
   {
-    std::vector<std::int32_t> loc_pos(local_slaves.size(), 0);
-    for (std::size_t i = 0; i < local_slaves.size(); ++i)
-    {
-      const std::int32_t master_min = masters_offsets[i];
-      const std::int32_t master_max = masters_offsets[i + 1];
-      std::copy(masters_out.begin() + master_min,
-                masters_out.begin() + master_max,
-                local_masters.begin() + local_offsets[i] + loc_pos[i]);
-      std::copy(coefficients_out.begin() + master_min,
-                coefficients_out.begin() + master_max,
-                local_coeffs.begin() + local_offsets[i] + loc_pos[i]);
-      std::copy(owners_out.begin() + master_min,
-                owners_out.begin() + master_max,
-                local_owners.begin() + local_offsets[i] + loc_pos[i]);
-      loc_pos[i] += master_max - master_min;
-    }
-
-    // Insert remote contributions
-    for (std::size_t i = 0; i < slave_indices_remote.size(); ++i)
-    {
-      const std::int32_t master_min = offproc_offsets[i];
-      const std::int32_t master_max = offproc_offsets[i + 1];
-      const std::int32_t slave_index = slave_indices_remote[i];
-      std::copy(offproc_masters.begin() + master_min,
-                offproc_masters.begin() + master_max,
-                local_masters.begin() + local_offsets[slave_index]
-                    + loc_pos[slave_index]);
-      std::copy(offproc_coeffs.begin() + master_min,
-                offproc_coeffs.begin() + master_max,
-                local_coeffs.begin() + local_offsets[slave_index]
-                    + loc_pos[slave_index]);
-      std::copy(offproc_owners.begin() + master_min,
-                offproc_owners.begin() + master_max,
-                local_owners.begin() + local_offsets[slave_index]
-                    + loc_pos[slave_index]);
-      loc_pos[slave_index] += master_max - master_min;
-    }
+    const std::int32_t master_min = masters_offsets[i];
+    const std::int32_t master_max = masters_offsets[i + 1];
+    std::copy(masters_out.begin() + master_min,
+              masters_out.begin() + master_max,
+              local_masters.begin() + local_offsets[i] + loc_pos[i]);
+    std::copy(coefficients_out.begin() + master_min,
+              coefficients_out.begin() + master_max,
+              local_coeffs.begin() + local_offsets[i] + loc_pos[i]);
+    std::copy(owners_out.begin() + master_min, owners_out.begin() + master_max,
+              local_owners.begin() + local_offsets[i] + loc_pos[i]);
+    loc_pos[i] += master_max - master_min;
   }
-  // Distribute ghost data
-  dolfinx_mpc::mpc_data ghost_data
-      = dolfinx_mpc::distribute_ghost_data<PetscScalar>(
-          local_slaves, local_masters, local_coeffs, local_owners,
-          num_masters_per_slave, imap, block_size);
 
-  // Add ghost data to existing arrays
-  const std::vector<std::int32_t>& ghost_slaves = ghost_data.slaves;
-  local_slaves.insert(std::end(local_slaves), std::cbegin(ghost_slaves),
-                      std::cend(ghost_slaves));
-  const std::vector<std::int64_t>& ghost_masters = ghost_data.masters;
-  local_masters.insert(std::end(local_masters), std::cbegin(ghost_masters),
-                       std::cend(ghost_masters));
-  const std::vector<std::int32_t>& ghost_num = ghost_data.offsets;
-  num_masters_per_slave.insert(std::end(num_masters_per_slave),
-                               std::cbegin(ghost_num), std::cend(ghost_num));
-  const std::vector<PetscScalar>& ghost_coeffs = ghost_data.coeffs;
-  local_coeffs.insert(std::end(local_coeffs), std::cbegin(ghost_coeffs),
-                      std::cend(ghost_coeffs));
-  const std::vector<std::int32_t>& ghost_owner_ranks = ghost_data.owners;
-  local_owners.insert(std::end(local_owners), std::cbegin(ghost_owner_ranks),
-                      std::cend(ghost_owner_ranks));
+  // Insert remote contributions
+  for (std::size_t i = 0; i < slave_indices_remote.size(); ++i)
+  {
+    const std::int32_t master_min = offproc_offsets[i];
+    const std::int32_t master_max = offproc_offsets[i + 1];
+    const std::int32_t slave_index = slave_indices_remote[i];
+    std::copy(offproc_masters.begin() + master_min,
+              offproc_masters.begin() + master_max,
+              local_masters.begin() + local_offsets[slave_index]
+                  + loc_pos[slave_index]);
+    std::copy(offproc_coeffs.begin() + master_min,
+              offproc_coeffs.begin() + master_max,
+              local_coeffs.begin() + local_offsets[slave_index]
+                  + loc_pos[slave_index]);
+    std::copy(offproc_owners.begin() + master_min,
+              offproc_owners.begin() + master_max,
+              local_owners.begin() + local_offsets[slave_index]
+                  + loc_pos[slave_index]);
+    loc_pos[slave_index] += master_max - master_min;
+  }
+}
+// Distribute ghost data
+dolfinx_mpc::mpc_data ghost_data
+    = dolfinx_mpc::distribute_ghost_data<PetscScalar>(
+        local_slaves, local_masters, local_coeffs, local_owners,
+        num_masters_per_slave, imap, block_size);
 
-  // Compute offsets
-  std::vector<std::int32_t> offsets(num_masters_per_slave.size() + 1, 0);
-  std::partial_sum(num_masters_per_slave.begin(), num_masters_per_slave.end(),
-                   offsets.begin() + 1);
+// Add ghost data to existing arrays
+const std::vector<std::int32_t>& ghost_slaves = ghost_data.slaves;
+local_slaves.insert(std::end(local_slaves), std::cbegin(ghost_slaves),
+                    std::cend(ghost_slaves));
+const std::vector<std::int64_t>& ghost_masters = ghost_data.masters;
+local_masters.insert(std::end(local_masters), std::cbegin(ghost_masters),
+                     std::cend(ghost_masters));
+const std::vector<std::int32_t>& ghost_num = ghost_data.offsets;
+num_masters_per_slave.insert(std::end(num_masters_per_slave),
+                             std::cbegin(ghost_num), std::cend(ghost_num));
+const std::vector<PetscScalar>& ghost_coeffs = ghost_data.coeffs;
+local_coeffs.insert(std::end(local_coeffs), std::cbegin(ghost_coeffs),
+                    std::cend(ghost_coeffs));
+const std::vector<std::int32_t>& ghost_owner_ranks = ghost_data.owners;
+local_owners.insert(std::end(local_owners), std::cbegin(ghost_owner_ranks),
+                    std::cend(ghost_owner_ranks));
 
-  dolfinx_mpc::mpc_data output;
-  output.offsets = offsets;
-  output.masters = local_masters;
-  output.coeffs = local_coeffs;
-  output.owners = local_owners;
-  output.slaves = local_slaves;
-  return output;
+// Compute offsets
+std::vector<std::int32_t> offsets(num_masters_per_slave.size() + 1, 0);
+std::partial_sum(num_masters_per_slave.begin(), num_masters_per_slave.end(),
+                 offsets.begin() + 1);
+
+dolfinx_mpc::mpc_data output;
+output.offsets = offsets;
+output.masters = local_masters;
+output.coeffs = local_coeffs;
+output.owners = local_owners;
+output.slaves = local_slaves;
+return output;
 }
 //-----------------------------------------------------------------------------
 mpc_data dolfinx_mpc::create_contact_inelastic_condition(

--- a/cpp/ContactConstraint.h
+++ b/cpp/ContactConstraint.h
@@ -14,7 +14,7 @@
 namespace dolfinx_mpc
 {
 
-/// Create a slip contact condition between two sets of facets
+/// Create a slip condition between two sets of facets
 /// @param[in] V The mpc function space
 /// @param[in] meshtags The meshtag
 /// @param[in] slave_marker Tag for the first interface

--- a/cpp/PeriodicConstraint.cpp
+++ b/cpp/PeriodicConstraint.cpp
@@ -9,8 +9,6 @@
 #include <dolfinx/fem/DirichletBC.h>
 #include <dolfinx/geometry/BoundingBoxTree.h>
 #include <dolfinx/geometry/utils.h>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xview.hpp>
 namespace
 {
 
@@ -604,7 +602,7 @@ dolfinx_mpc::mpc_data topological_condition(
         = dolfinx::fem::locate_dofs_topological(*V.get(), meshtag->dim(),
                                                 entities);
     const std::vector<std::int8_t> bc_marker
-        = dolfinx_mpc::is_bc<TCB_SPAN_HAVE_CPP17>(*V, slave_blocks, bcs);
+        = dolfinx_mpc::is_bc<T>(*V, slave_blocks, bcs);
     std::vector<std::int32_t> reduced_blocks;
     for (std::size_t i = 0; i < bc_marker.size(); i++)
       if (!bc_marker[i])

--- a/cpp/PeriodicConstraint.cpp
+++ b/cpp/PeriodicConstraint.cpp
@@ -113,8 +113,8 @@ dolfinx_mpc::mpc_data _create_periodic_condition(
         mapped_T(mapped_T_b.data(), T_shape);
 
     // Tabulate dof coordinates for each dof
-    auto [x, x_shape]
-        = dolfinx_mpc::tabulate_dof_coordinates(V, local_blocks, slave_cells);
+    auto [x, x_shape] = dolfinx_mpc::tabulate_dof_coordinates(
+        V, local_blocks, slave_cells, true);
     // Map all slave coordinates using the relation
     std::vector<double> mapped_x = relation(x);
     std::experimental::mdspan<

--- a/cpp/PeriodicConstraint.cpp
+++ b/cpp/PeriodicConstraint.cpp
@@ -28,11 +28,7 @@ namespace
 template <typename T>
 dolfinx_mpc::mpc_data _create_periodic_condition(
     const dolfinx::fem::FunctionSpace& V, std::span<std::int32_t> slave_blocks,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     double scale,
     const std::function<const std::int32_t(const std::int32_t&)>& parent_map,
     const dolfinx::fem::FunctionSpace& parent_space)
@@ -120,11 +116,7 @@ dolfinx_mpc::mpc_data _create_periodic_condition(
     auto [x, x_shape]
         = dolfinx_mpc::tabulate_dof_coordinates(V, local_blocks, slave_cells);
     // Map all slave coordinates using the relation
-    std::experimental::mdspan<
-        double, std::experimental::extents<std::size_t, 3,
-                                           std::experimental::dynamic_extent>>
-        xs(x.data(), x_shape);
-    std::vector<double> mapped_x = relation(xs);
+    std::vector<double> mapped_x = relation(x);
     std::experimental::mdspan<
         double, std::experimental::extents<std::size_t, 3,
                                            std::experimental::dynamic_extent>>
@@ -513,11 +505,7 @@ dolfinx_mpc::mpc_data geometrical_condition(
             std::experimental::extents<std::size_t, 3,
                                        std::experimental::dynamic_extent>>)>&
         indicator,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<T>>>& bcs,
     double scale, bool collapse)
 {
@@ -579,15 +567,10 @@ dolfinx_mpc::mpc_data topological_condition(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
     const std::shared_ptr<const dolfinx::mesh::MeshTags<std::int32_t>> meshtag,
     const std::int32_t tag,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<T>>>& bcs,
     double scale, bool collapse)
 {
-
   std::vector<std::int32_t> entities = meshtag->find(tag);
 
   if (collapse)
@@ -644,11 +627,7 @@ dolfinx_mpc::mpc_data dolfinx_mpc::create_periodic_condition_geometrical(
             std::experimental::extents<std::size_t, 3,
                                        std::experimental::dynamic_extent>>)>&
         indicator,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<double>>>&
         bcs,
     double scale, bool collapse)
@@ -665,11 +644,7 @@ dolfinx_mpc::mpc_data dolfinx_mpc::create_periodic_condition_geometrical(
             std::experimental::extents<std::size_t, 3,
                                        std::experimental::dynamic_extent>>)>&
         indicator,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<
         std::shared_ptr<const dolfinx::fem::DirichletBC<std::complex<double>>>>&
         bcs,
@@ -683,11 +658,7 @@ dolfinx_mpc::mpc_data dolfinx_mpc::create_periodic_condition_topological(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
     const std::shared_ptr<const dolfinx::mesh::MeshTags<std::int32_t>> meshtag,
     const std::int32_t tag,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<double>>>&
         bcs,
     double scale, bool collapse)
@@ -700,11 +671,7 @@ dolfinx_mpc::mpc_data dolfinx_mpc::create_periodic_condition_topological(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
     const std::shared_ptr<const dolfinx::mesh::MeshTags<std::int32_t>> meshtag,
     const std::int32_t tag,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<
         std::shared_ptr<const dolfinx::fem::DirichletBC<std::complex<double>>>>&
         bcs,

--- a/cpp/PeriodicConstraint.h
+++ b/cpp/PeriodicConstraint.h
@@ -20,11 +20,7 @@ mpc_data create_periodic_condition_geometrical(
             std::experimental::extents<std::size_t, 3,
                                        std::experimental::dynamic_extent>>)>&
         indicator,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<double>>>&
         bcs,
     double scale, bool collapse);
@@ -37,11 +33,7 @@ mpc_data create_periodic_condition_geometrical(
             std::experimental::extents<std::size_t, 3,
                                        std::experimental::dynamic_extent>>)>&
         indicator,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<
         std::shared_ptr<const dolfinx::fem::DirichletBC<std::complex<double>>>>&
         bcs,
@@ -51,11 +43,7 @@ mpc_data create_periodic_condition_topological(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
     const std::shared_ptr<const dolfinx::mesh::MeshTags<std::int32_t>> meshtag,
     const std::int32_t tag,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<double>>>&
         bcs,
     double scale, bool collapse);
@@ -64,11 +52,7 @@ mpc_data create_periodic_condition_topological(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
     const std::shared_ptr<const dolfinx::mesh::MeshTags<std::int32_t>> meshtag,
     const std::int32_t tag,
-    const std::function<std::vector<double>(
-        std::experimental::mdspan<
-            const double,
-            std::experimental::extents<
-                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
+    const std::function<std::vector<double>(std::span<const double>)>& relation,
     const std::vector<
         std::shared_ptr<const dolfinx::fem::DirichletBC<std::complex<double>>>>&
         bcs,

--- a/cpp/PeriodicConstraint.h
+++ b/cpp/PeriodicConstraint.h
@@ -6,8 +6,6 @@
 
 #include "ContactConstraint.h"
 #include <dolfinx/fem/DirichletBC.h>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xtensor.hpp>
 
 namespace dolfinx_mpc
 

--- a/cpp/PeriodicConstraint.h
+++ b/cpp/PeriodicConstraint.h
@@ -14,20 +14,34 @@ namespace dolfinx_mpc
 {
 mpc_data create_periodic_condition_geometrical(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
-    const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
+    const std::function<std::vector<std::int8_t>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<std::size_t, 3,
+                                       std::experimental::dynamic_extent>>)>&
         indicator,
-    const std::function<xt::xarray<double>(const xt::xtensor<double, 2>&)>&
-        relation,
+    const std::function<std::vector<double>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<
+                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
     const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<double>>>&
         bcs,
     double scale, bool collapse);
 
 mpc_data create_periodic_condition_geometrical(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
-    const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
+    const std::function<std::vector<std::int8_t>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<std::size_t, 3,
+                                       std::experimental::dynamic_extent>>)>&
         indicator,
-    const std::function<xt::xarray<double>(const xt::xtensor<double, 2>&)>&
-        relation,
+    const std::function<std::vector<double>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<
+                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
     const std::vector<
         std::shared_ptr<const dolfinx::fem::DirichletBC<std::complex<double>>>>&
         bcs,
@@ -37,8 +51,11 @@ mpc_data create_periodic_condition_topological(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
     const std::shared_ptr<const dolfinx::mesh::MeshTags<std::int32_t>> meshtag,
     const std::int32_t tag,
-    const std::function<xt::xarray<double>(const xt::xtensor<double, 2>&)>&
-        relation,
+    const std::function<std::vector<double>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<
+                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
     const std::vector<std::shared_ptr<const dolfinx::fem::DirichletBC<double>>>&
         bcs,
     double scale, bool collapse);
@@ -47,8 +64,11 @@ mpc_data create_periodic_condition_topological(
     const std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
     const std::shared_ptr<const dolfinx::mesh::MeshTags<std::int32_t>> meshtag,
     const std::int32_t tag,
-    const std::function<xt::xarray<double>(const xt::xtensor<double, 2>&)>&
-        relation,
+    const std::function<std::vector<double>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<
+                std::size_t, 3, std::experimental::dynamic_extent>>)>& relation,
     const std::vector<
         std::shared_ptr<const dolfinx::fem::DirichletBC<std::complex<double>>>>&
         bcs,

--- a/cpp/assemble_matrix.cpp
+++ b/cpp/assemble_matrix.cpp
@@ -476,7 +476,7 @@ void assemble_cells_impl(
         for (std::int32_t k = 0; k < bs0; ++k)
         {
           if (bc0[bs0 * dofs0[i] + k])
-            std::fill_n(std::next(Aeb.begin(), ndim1 * (bs0 * i + k)), ndim0,
+            std::fill_n(std::next(Aeb.begin(), ndim1 * (bs0 * i + k)), ndim1,
                         T(0));
         }
       }
@@ -504,7 +504,6 @@ void assemble_cells_impl(
     }
     mat_add_block_values(dofs0, dofs1, _Ae);
   }
-  std::cout << "POST LOOP\n";
 }
 //-----------------------------------------------------------------------------
 template <typename T>

--- a/cpp/assemble_matrix.cpp
+++ b/cpp/assemble_matrix.cpp
@@ -284,9 +284,8 @@ void assemble_exterior_facets(
     std::span<const std::int32_t> x_dofs = x_dofmap.links(cell);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
-      std::copy_n(
-          std::next(x_g.begin(), 3 * x_dofs[i]),3,
-          std::next(coordinate_dofs.begin(), 3 * i));
+      std::copy_n(std::next(x_g.begin(), 3 * x_dofs[i]), 3,
+                  std::next(coordinate_dofs.begin(), 3 * i));
     }
     // Tabulate tensor
     std::fill(Ae.data(), Ae.data() + Ae.size(), 0);
@@ -411,9 +410,8 @@ void assemble_cells_impl(
     std::span<const int32_t> x_dofs = x_dofmap.links(cell);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
-      std::copy_n(
-          std::next(x_g.begin(), 3 * x_dofs[i]),3,
-          std::next(coordinate_dofs.begin(), 3 * i));
+      std::copy_n(std::next(x_g.begin(), 3 * x_dofs[i]), 3,
+                  std::next(coordinate_dofs.begin(), 3 * i));
     }
     // Tabulate tensor
     std::fill(Ae.data(), Ae.data() + Ae.size(), 0);

--- a/cpp/assemble_matrix.cpp
+++ b/cpp/assemble_matrix.cpp
@@ -132,7 +132,8 @@ void modify_mpc_cell(
 
   const int ndim0 = bs[0] * num_dofs[0];
   const int ndim1 = bs[1] * num_dofs[1];
-  assert(scratch_memory.size() >= 2 * ndim0 * ndim1 + ndim0 + ndim1);
+  assert(scratch_memory.size()
+         >= std::size_t(2 * ndim0 * ndim1 + ndim0 + ndim1));
   std::fill(scratch_memory.begin(), scratch_memory.end(), T(0));
 
   std::experimental::mdspan<T, std::experimental::dextents<std::size_t, 2>>

--- a/cpp/assemble_matrix.h
+++ b/cpp/assemble_matrix.h
@@ -9,7 +9,6 @@
 #include <dolfinx/fem/DirichletBC.h>
 #include <dolfinx/fem/Form.h>
 #include <functional>
-#include <xtensor/xcomplex.hpp>
 
 namespace dolfinx_mpc
 {

--- a/cpp/assemble_vector.h
+++ b/cpp/assemble_vector.h
@@ -11,7 +11,6 @@
 #include <dolfinx/fem/DirichletBC.h>
 #include <dolfinx/fem/Form.h>
 #include <functional>
-#include <xtensor/xcomplex.hpp>
 
 namespace dolfinx_mpc
 {

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -525,16 +525,18 @@ dolfinx_mpc::evaluate_basis_functions(
   const int num_sub_elements = element->num_sub_elements();
   if (num_sub_elements > 1 and num_sub_elements != bs_element)
   {
-    throw std::runtime_error("Function::eval is not supported for mixed "
-                             "elements. Extract subspaces.");
+    throw std::runtime_error(
+        "Evaluation of basis functions is not supported for mixed "
+        "elements. Extract subspaces.");
   }
 
   // Return early if we have no points
   std::array<std::size_t, 4> basis_shape
       = element->basix_element().tabulate_shape(0, num_points);
 
-  assert(basis_shape[2] == element->space_dimension() / bs_element);
-  assert(basis_shape[3] == element->value_size() / bs_element);
+  assert(basis_shape[2]
+         == std::size_t(element->space_dimension() / bs_element));
+  assert(basis_shape[3] == std::size_t(element->value_size() / bs_element));
   std::array<std::size_t, 3> reference_shape
       = {basis_shape[1], basis_shape[2], basis_shape[3]};
   std::vector<double> output_basis(std::reduce(
@@ -542,15 +544,6 @@ dolfinx_mpc::evaluate_basis_functions(
 
   if (num_points == 0)
     return {output_basis, reference_shape};
-
-  // If the space has sub elements, concatenate the evaluations on the sub
-  // elements
-  if (const int num_sub_elements = element->num_sub_elements();
-      num_sub_elements > 1 && num_sub_elements != bs_element)
-  {
-    throw std::runtime_error("Function::eval is not supported for mixed "
-                             "elements. Extract subspaces.");
-  }
 
   std::span<const std::uint32_t> cell_info;
   if (element->needs_dof_transformations())

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -119,7 +119,6 @@ xt::xtensor<double, 2> dolfinx_mpc::get_basis_functions(
   namespace stdex = std::experimental;
   using cmdspan4_t
       = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
-  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
   using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
   using cmdspan2_t
       = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -19,7 +19,7 @@
 #include <dolfinx/la/SparsityPattern.h>
 #include <dolfinx/la/petsc.h>
 #include <span>
-#include <xtensor/xtensor.hpp>
+
 namespace dolfinx_mpc
 {
 
@@ -44,14 +44,6 @@ struct mpc_data
 
 template <typename T>
 class MultiPointConstraint;
-
-/// Get basis values for all degrees at physical coordiante in a given cell
-/// @param[in] V       The function space
-/// @param[in] x   The physical coordinate
-/// @param[in] index   The cell_index
-xt::xtensor<double, 2>
-get_basis_functions(std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
-                    std::span<const double> x, const int index);
 
 /// Given a function space, compute its shared entities
 dolfinx::graph::AdjacencyList<int>

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -627,12 +627,14 @@ evaluate_basis_functions(const dolfinx::fem::FunctionSpace& V,
 /// @param[in] dofs Array of dofs (not unrolled with block size)
 /// @param[in] cells An array of cell indices. cells[i] is the index
 /// of a cell that contains dofs[i]
-/// @returns The dof coordinates flattened in xyzxyz format, where the [3*i,
-/// 3*(i+1)] entries are the coordinates of the ith dof
+/// @param[in] transposed If true return coordiantes in xxyyzz format. Else
+/// xyzxzyxzy
+/// @returns The dof coordinates flattened in the appropriate format
 std::pair<std::vector<double>, std::array<std::size_t, 2>>
 tabulate_dof_coordinates(const dolfinx::fem::FunctionSpace& V,
                          std::span<const std::int32_t> dofs,
-                         std::span<const std::int32_t> cells);
+                         std::span<const std::int32_t> cells,
+                         bool transposed = false);
 
 /// From a Mesh, find which cells collide with a set of points.
 /// @note Uses the GJK algorithm, see dolfinx::geometry::compute_distance_gjk

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -617,7 +617,7 @@ dolfinx_mpc::mpc_data distribute_ghost_data(
 /// (num_points, number_of_dofs, value_size). Flattened row major
 std::pair<std::vector<double>, std::array<std::size_t, 3>>
 evaluate_basis_functions(const dolfinx::fem::FunctionSpace& V,
-                         const xt::xtensor<double, 2>& x,
+                         std::span<const double> x,
                          const std::span<const std::int32_t>& cells);
 
 //-----------------------------------------------------------------------------

--- a/python/demos/demo_contact_2D.py
+++ b/python/demos/demo_contact_2D.py
@@ -105,6 +105,7 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = True, quad:
 
     with Timer("~Contact: Create contact constraint"):
         nh = create_normal_approximation(V, mt, 4)
+        from IPython import embed;embed()
         mpc.create_contact_slip_condition(mt, 4, 9, nh)
 
     with Timer("~Contact: Add non-slip condition at bottom interface"):

--- a/python/demos/demo_contact_2D.py
+++ b/python/demos/demo_contact_2D.py
@@ -105,7 +105,6 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = True, quad:
 
     with Timer("~Contact: Create contact constraint"):
         nh = create_normal_approximation(V, mt, 4)
-        from IPython import embed;embed()
         mpc.create_contact_slip_condition(mt, 4, 9, nh)
 
     with Timer("~Contact: Add non-slip condition at bottom interface"):

--- a/python/dolfinx_mpc/mpc.cpp
+++ b/python/dolfinx_mpc/mpc.cpp
@@ -28,8 +28,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xtensor.hpp>
+
 namespace py = pybind11;
 
 namespace dolfinx_mpc_wrappers
@@ -37,31 +36,6 @@ namespace dolfinx_mpc_wrappers
 void mpc(py::module& m)
 {
 
-  m.def("get_basis_functions",
-        [](std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
-           const py::array_t<double, py::array::c_style>& x, const int index)
-        {
-          const std::size_t x_s0 = x.ndim() == 1 ? 1 : x.shape(0);
-          const std::int32_t gdim = V->mesh()->geometry().dim();
-          xt::xtensor<double, 2> _x
-              = xt::zeros<double>({x_s0, static_cast<std::size_t>(gdim)});
-          auto xx = x.unchecked();
-          if (xx.ndim() == 1)
-          {
-            for (py::ssize_t i = 0; i < gdim; i++)
-              _x(0, i) = xx(i);
-          }
-          else if (xx.ndim() == 2)
-          {
-            for (py::ssize_t i = 0; i < xx.shape(0); i++)
-              for (py::ssize_t j = 0; j < gdim; j++)
-                _x(i, j) = xx(i, j);
-          }
-          const xt::xtensor<double, 2> basis_function
-              = dolfinx_mpc::get_basis_functions(V, _x, index);
-          return py::array_t<double>(basis_function.shape(),
-                                     basis_function.data());
-        });
   m.def("compute_shared_indices", &dolfinx_mpc::compute_shared_indices);
 
   // dolfinx_mpc::MultiPointConstraint

--- a/python/setup.py
+++ b/python/setup.py
@@ -15,7 +15,7 @@ if sys.version_info <= (3, 8):
 
 VERSION = "0.5.1.dev0"
 
-REQUIREMENTS = ["numpy>=1.21", "fenics-dolfinx>=0.5.0"]
+REQUIREMENTS = ["numpy>=1.21", "fenics-dolfinx>0.5.1"]
 
 
 class CMakeExtension(Extension):


### PR DESCRIPTION
Remove xtensor as md array dependency in C++ layer (following https://github.com/FEniCS/dolfinx/pull/2356)

Instead, flat `std::vector` or `std::array` structures will be used to store data, and 
`std::experimental::mdspan` will be used to handle multidimensional data (https://en.cppreference.com/w/cpp/container/mdspan).

The Python-interface should not be affected by this PR.