### PR TITLE
Implement Hermitian pre-multiplication for complex values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ $Au=b$, with the additional constraints written on the form $K\hat u=u$, where $
 
 We then solve the system 
 $K^T A K \hat u = K^T b$, where $K^T A K$ is symmetric if $A$ was symmetric.
+(For complex numbers, we use the Hermitian transpose and solve the system $\overline{K^T} A K \hat u = \overline{K^T} b$, where $\overline{K^T}$ is the complex conjugate of $K^T$, and $\overline{K^T} A K$ is Hermitian if $A$ was Hermitian.)
 
 If we include boundary conditions on the form $u=g$, we 
 assemble the system

--- a/cpp/assemble_matrix.cpp
+++ b/cpp/assemble_matrix.cpp
@@ -204,7 +204,7 @@ void modify_mpc_cell(
     for (std::uint32_t j = 0; j < num_dofs[1]; ++j)
       for (int k = 0; k < bs[1]; ++k)
       {
-        if constexpr(std::is_vector_v<T>)
+        if constexpr(std::is_scalar_v<T>)
           // Use the standard transpose for type double
           Acol[j * bs[1] + k]
               = flattened_coeffs[0][i]
@@ -251,7 +251,7 @@ void modify_mpc_cell(
 
       row[0] = flattened_masters[0][i];
       col[0] = flattened_masters[1][j];
-      if constexpr (std::is_vector_v<T>)
+      if constexpr (std::is_scalar_v<T>)
         // Standard transpose for type double
         A0[0] = flattened_coeffs[0][i] * flattened_coeffs[1][j]
                 * Ae_original(flattened_slaves[0][i], flattened_slaves[1][j]);

--- a/cpp/assemble_matrix.cpp
+++ b/cpp/assemble_matrix.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 Jorgen S. Dokken and Nathan Sime
+// Copyright (C) 2020-2022 Jorgen S. Dokken, Nathan Sime, and Connor D. Pierce
 //
 // This file is part of DOLFINX_MPC
 //

--- a/cpp/assemble_matrix.cpp
+++ b/cpp/assemble_matrix.cpp
@@ -86,7 +86,6 @@ void modify_mpc_cell_rows(
     std::vector<std::int32_t> unrolled_dofs,
     std::experimental::mdspan<double, std::experimental::dextents<std::size_t, 2>> Ae_stripped)
 {
-  std::vector<std::int32_t> unrolled_dofs(ndim1);
   std::array<std::int32_t, 1> row;
   auto Acol = scratch_memory.subspan(2 * ndim0 * ndim1 + ndim0, ndim1);
   for (std::size_t i = 0; i < num_flattened_masters[0]; ++i)

--- a/cpp/assemble_matrix.cpp
+++ b/cpp/assemble_matrix.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 Jorgen S. Dokken, Nathan Sime, and Connor D. Pierce
+// Copyright (C) 2020-2022 Jorgen S. Dokken and Nathan Sime
 //
 // This file is part of DOLFINX_MPC
 //
@@ -68,146 +68,6 @@ void fill_stripped_matrix(
     }
   }
 };
-
-/// Loop over all masters for the MPC applied to rows. Insert contributions in columns
-void modify_mpc_cell_rows(
-    const std::function<int(const std::span<const std::int32_t>&,
-                            const std::span<const std::int32_t>&,
-                            const std::span<const double>)>& mat_set,
-    const int ndim0, const int ndim1,
-    const std::array<const std::uint32_t, 2>& num_dofs,
-    const std::array<const std::span<const int32_t>, 2>& dofs,
-    std::array<std::size_t, 2> num_flattened_masters,
-    const std::array<const int, 2>& bs,
-    std::span<double> scratch_memory,
-    std::array<std::vector<std::int32_t>, 2> flattened_masters,
-    std::array<std::vector<std::int32_t>, 2> flattened_slaves,
-    std::array<std::vector<double>, 2> flattened_coeffs,
-    std::vector<std::int32_t> unrolled_dofs,
-    std::experimental::mdspan<double, std::experimental::dextents<std::size_t, 2>> Ae_stripped)
-{
-  std::array<std::int32_t, 1> row;
-  auto Acol = scratch_memory.subspan(2 * ndim0 * ndim1 + ndim0, ndim1);
-  for (std::size_t i = 0; i < num_flattened_masters[0]; ++i)
-  {
-
-    // Unroll dof blocks and add column contribution
-    for (std::uint32_t j = 0; j < num_dofs[1]; ++j)
-      for (int k = 0; k < bs[1]; ++k)
-      {
-        Acol[j * bs[1] + k]
-            = flattened_coeffs[0][i]
-              * Ae_stripped(flattened_slaves[0][i], j * bs[1] + k);
-        unrolled_dofs[j * bs[1] + k] = dofs[1][j] * bs[1] + k;
-      }
-
-    // Insert modified entries
-    row[0] = flattened_masters[0][i];
-    mat_set(row, unrolled_dofs, Acol);
-  }
-}
-
-/// Loop over all masters for the MPC applied to rows. Insert contributions in columns
-void modify_mpc_cell_rows(
-    const std::function<int(const std::span<const std::int32_t>&,
-                            const std::span<const std::int32_t>&,
-                            const std::span<const std::complex<double>>)>& mat_set,
-    const int ndim0, const int ndim1,
-    const std::array<const std::uint32_t, 2>& num_dofs,
-    const std::array<const std::span<const int32_t>, 2>& dofs,
-    std::array<std::size_t, 2> num_flattened_masters,
-    const std::array<const int, 2>& bs,
-    std::span<std::complex<double>> scratch_memory,
-    std::array<std::vector<std::int32_t>, 2> flattened_masters,
-    std::array<std::vector<std::int32_t>, 2> flattened_slaves,
-    std::array<std::vector<std::complex<double>>, 2> flattened_coeffs,
-    std::vector<std::int32_t> unrolled_dofs,
-    std::experimental::mdspan<std::complex<double>, 
-                              std::experimental::dextents<std::size_t, 2>> Ae_stripped)
-{
-  std::array<std::int32_t, 1> row;
-  auto Acol = scratch_memory.subspan(2 * ndim0 * ndim1 + ndim0, ndim1);
-  for (std::size_t i = 0; i < num_flattened_masters[0]; ++i)
-  {
-
-    // Unroll dof blocks and add column contribution
-    for (std::uint32_t j = 0; j < num_dofs[1]; ++j)
-      for (int k = 0; k < bs[1]; ++k)
-      {
-        Acol[j * bs[1] + k]
-            = std::conj(flattened_coeffs[0][i])
-              * Ae_stripped(flattened_slaves[0][i], j * bs[1] + k);
-        unrolled_dofs[j * bs[1] + k] = dofs[1][j] * bs[1] + k;
-      }
-
-    // Insert modified entries
-    row[0] = flattened_masters[0][i];
-    mat_set(row, unrolled_dofs, Acol);
-  }
-}
-
-// Loop through masters on a cell and add the quadratic contribution of the
-// multi-point constraint (real version)
-void modify_mpc_cell_masters(
-    const std::function<int(const std::span<const std::int32_t>&,
-                            const std::span<const std::int32_t>&,
-                            const std::span<const double>)>& mat_set,
-    const std::array<const std::span<const int32_t>, 2>& dofs,
-    std::array<std::size_t, 2> num_flattened_masters,
-    std::array<std::vector<std::int32_t>, 2> flattened_masters,
-    std::array<std::vector<std::int32_t>, 2> flattened_slaves,
-    std::array<std::vector<double>, 2> flattened_coeffs,
-    std::experimental::mdspan<double, std::experimental::dextents<std::size_t, 2>> Ae_original)
-{
-  std::array<std::int32_t, 1> row;
-  std::array<std::int32_t, 1> col;
-  std::array<double, 1> A0;
-  for (std::size_t i = 0; i < num_flattened_masters[0]; ++i)
-  {
-    // Loop through other masters on the same cell and add in contribution
-    for (std::size_t j = 0; j < num_flattened_masters[1]; ++j)
-    {
-
-      row[0] = flattened_masters[0][i];
-      col[0] = flattened_masters[1][j];
-      A0[0] = flattened_coeffs[0][i] * flattened_coeffs[1][j]
-              * Ae_original(flattened_slaves[0][i], flattened_slaves[1][j]);
-      mat_set(row, col, A0);
-    }
-  }
-}
-
-// Loop through masters on a cell and add the quadratic contribution of the
-// multi-point constraint (complex version)
-void modify_mpc_cell_masters(
-    const std::function<int(const std::span<const std::int32_t>&,
-                            const std::span<const std::int32_t>&,
-                            const std::span<const std::complex<double>>)>& mat_set,
-    const std::array<const std::span<const int32_t>, 2>& dofs,
-    std::array<std::size_t, 2> num_flattened_masters,
-    std::array<std::vector<std::int32_t>, 2> flattened_masters,
-    std::array<std::vector<std::int32_t>, 2> flattened_slaves,
-    std::array<std::vector<std::complex<double>>, 2> flattened_coeffs,
-    std::experimental::mdspan<std::complex<double>, 
-                              std::experimental::dextents<std::size_t, 2>> Ae_original)
-{
-  std::array<std::int32_t, 1> row;
-  std::array<std::int32_t, 1> col;
-  std::array<std::complex<double>, 1> A0;
-  for (std::size_t i = 0; i < num_flattened_masters[0]; ++i)
-  {
-    // Loop through other masters on the same cell and add in contribution
-    for (std::size_t j = 0; j < num_flattened_masters[1]; ++j)
-    {
-
-      row[0] = flattened_masters[0][i];
-      col[0] = flattened_masters[1][j];
-      A0[0] = std::conj(flattened_coeffs[0][i]) * flattened_coeffs[1][j]
-              * Ae_original(flattened_slaves[0][i], flattened_slaves[1][j]);
-      mat_set(row, col, A0);
-    }
-  }
-}
 
 /// Modify local element matrix Ae with MPC contributions, and insert non-local
 /// contributions in the correct places
@@ -329,12 +189,35 @@ void modify_mpc_cell(
     assert(num_flattened_masters[axis] == flattened_masters[axis].size());
 
   // Data structures used for insertion of master contributions
-  std::vector<std::int32_t> unrolled_dofs(ndim0);
-  auto Arow = scratch_memory.subspan(2 * ndim0 * ndim1, ndim0);
+  std::array<std::int32_t, 1> row;
   std::array<std::int32_t, 1> col;
+  std::array<T, 1> A0;
+  auto Arow = scratch_memory.subspan(2 * ndim0 * ndim1, ndim0);
+  auto Acol = scratch_memory.subspan(2 * ndim0 * ndim1 + ndim0, ndim1);
+  // Loop over all masters for the MPC applied to rows.
+  // Insert contributions in columns
+  std::vector<std::int32_t> unrolled_dofs(ndim1);
+  for (std::size_t i = 0; i < num_flattened_masters[0]; ++i)
+  {
+
+    // Unroll dof blocks and add column contribution
+    for (std::uint32_t j = 0; j < num_dofs[1]; ++j)
+      for (int k = 0; k < bs[1]; ++k)
+      {
+        Acol[j * bs[1] + k]
+            = flattened_coeffs[0][i]
+              * Ae_stripped(flattened_slaves[0][i], j * bs[1] + k);
+        unrolled_dofs[j * bs[1] + k] = dofs[1][j] * bs[1] + k;
+      }
+
+    // Insert modified entries
+    row[0] = flattened_masters[0][i];
+    mat_set(row, unrolled_dofs, Acol);
+  }
 
   // Loop over all masters for the MPC applied to columns.
   // Insert contributions in rows
+  unrolled_dofs.resize(ndim0);
   for (std::size_t i = 0; i < num_flattened_masters[1]; ++i)
   {
 
@@ -353,16 +236,19 @@ void modify_mpc_cell(
     mat_set(unrolled_dofs, col, Arow);
   }
 
-  // Loop over all masters for the MPC applied to rows.
-  // Insert contributions in columns
-  unrolled_dofs.resize(ndim1);
-  modify_mpc_cell_rows(mat_set, ndim0, ndim1, num_dofs, dofs, num_flattened_masters, bs,
-                       scratch_memory, flattened_masters, flattened_slaves, flattened_coeffs,
-                       unrolled_dofs, Ae_stripped);
+  for (std::size_t i = 0; i < num_flattened_masters[0]; ++i)
+  {
+    // Loop through other masters on the same cell and add in contribution
+    for (std::size_t j = 0; j < num_flattened_masters[1]; ++j)
+    {
 
-  // Loop through other masters on the same cell and add in contribution
-  modify_mpc_cell_masters(mat_set, dofs, num_flattened_masters, flattened_masters,
-                          flattened_slaves, flattened_coeffs, Ae_original);
+      row[0] = flattened_masters[0][i];
+      col[0] = flattened_masters[1][j];
+      A0[0] = flattened_coeffs[0][i] * flattened_coeffs[1][j]
+              * Ae_original(flattened_slaves[0][i], flattened_slaves[1][j]);
+      mat_set(row, col, A0);
+    }
+  }
 } // namespace
 
 //-----------------------------------------------------------------------------

--- a/cpp/assemble_vector.cpp
+++ b/cpp/assemble_vector.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2022 Jorgen S. Dokken, Nathan Sime, and Connor D. Pierce
+// Copyright (C) 2021 Jorgen S. Dokken & Nathan Sime
 //
 // This file is part of DOLFINX_MPC
 //
@@ -13,90 +13,6 @@
 
 namespace
 {
-/// Given a local element vector, move all slave contributions to the global
-/// (local to process) vector.
-/// @param [in, out] b The global (local to process) vector
-/// @param [in, out] b_local The local element vector
-/// @param [in] b_local_copy Copy of the local element vector
-/// @param [in] cell_blocks Dofmap for the blocks in the cell
-/// @param [in] num_dofs The number of degrees of freedom in the local vector
-/// @param [in] bs The element block size
-/// @param [in] is_slave Vector indicating if a dof is a slave
-/// @param [in] slaves The slave dofs (local to process)
-/// @param [in] masters Adjacency list with master dofs
-/// @param [in] coeffs Adjacency list with the master coefficients
-void modify_mpc_vec(
-    const std::span<double>& b, const std::span<double>& b_local,
-    const std::span<double>& b_local_copy,
-    const std::span<const std::int32_t>& cell_blocks, const int num_dofs,
-    const int bs, const std::vector<std::int8_t>& is_slave,
-    const std::span<const std::int32_t>& slaves,
-    const std::shared_ptr<const dolfinx::graph::AdjacencyList<std::int32_t>>&
-        masters,
-    const std::shared_ptr<const dolfinx::graph::AdjacencyList<double>>& coeffs)
-{
-
-  // NOTE: Should this be moved into the MPC constructor?
-  // Get local index of slaves in cell
-  std::vector<std::int32_t> local_index
-      = compute_local_slave_index(slaves, num_dofs, bs, cell_blocks, is_slave);
-
-  // Move contribution from each slave to corresponding master dof
-  for (std::size_t i = 0; i < local_index.size(); i++)
-  {
-    auto masters_i = masters->links(slaves[i]);
-    auto coeffs_i = coeffs->links(slaves[i]);
-    assert(masters_i.size() == coeffs_i.size());
-    for (std::size_t j = 0; j < masters_i.size(); j++)
-    {
-      b[masters_i[j]] += coeffs_i[j] * b_local_copy[local_index[i]];
-      b_local[local_index[i]] = 0;
-    }
-  }
-}
-
-/// Given a local element vector, move all slave contributions to the global
-/// (local to process) vector.
-/// @param [in, out] b The global (local to process) vector
-/// @param [in, out] b_local The local element vector
-/// @param [in] b_local_copy Copy of the local element vector
-/// @param [in] cell_blocks Dofmap for the blocks in the cell
-/// @param [in] num_dofs The number of degrees of freedom in the local vector
-/// @param [in] bs The element block size
-/// @param [in] is_slave Vector indicating if a dof is a slave
-/// @param [in] slaves The slave dofs (local to process)
-/// @param [in] masters Adjacency list with master dofs
-/// @param [in] coeffs Adjacency list with the master coefficients
-void modify_mpc_vec(
-    const std::span<std::complex<double>>& b,
-    const std::span<std::complex<double>>& b_local,
-    const std::span<std::complex<double>>& b_local_copy,
-    const std::span<const std::int32_t>& cell_blocks, const int num_dofs,
-    const int bs, const std::vector<std::int8_t>& is_slave,
-    const std::span<const std::int32_t>& slaves,
-    const std::shared_ptr<const dolfinx::graph::AdjacencyList<std::int32_t>>&
-        masters,
-    const std::shared_ptr<const dolfinx::graph::AdjacencyList<std::complex<double>>>& coeffs)
-{
-
-  // NOTE: Should this be moved into the MPC constructor?
-  // Get local index of slaves in cell
-  std::vector<std::int32_t> local_index
-      = compute_local_slave_index(slaves, num_dofs, bs, cell_blocks, is_slave);
-
-  // Move contribution from each slave to corresponding master dof
-  for (std::size_t i = 0; i < local_index.size(); i++)
-  {
-    auto masters_i = masters->links(slaves[i]);
-    auto coeffs_i = coeffs->links(slaves[i]);
-    assert(masters_i.size() == coeffs_i.size());
-    for (std::size_t j = 0; j < masters_i.size(); j++)
-    {
-      b[masters_i[j]] += std::conj(coeffs_i[j]) * b_local_copy[local_index[i]];
-      b_local[local_index[i]] = 0;
-    }
-  }
-}
 
 /// Assemble an integration kernel over a set of active entities, described
 /// through into vector of type T, and apply the multipoint constraint

--- a/cpp/assemble_vector.h
+++ b/cpp/assemble_vector.h
@@ -17,6 +17,53 @@ namespace dolfinx_mpc
 template <typename T>
 class MultiPointConstraint;
 
+/// Given a local element vector, move all slave contributions to the global
+/// (local to process) vector.
+/// @param [in, out] b The global (local to process) vector
+/// @param [in, out] b_local The local element vector
+/// @param [in] b_local_copy Copy of the local element vector
+/// @param [in] cell_blocks Dofmap for the blocks in the cell
+/// @param [in] num_dofs The number of degrees of freedom in the local vector
+/// @param [in] bs The element block size
+/// @param [in] is_slave Vector indicating if a dof is a slave
+/// @param [in] slaves The slave dofs (local to process)
+/// @param [in] masters Adjacency list with master dofs
+/// @param [in] coeffs Adjacency list with the master coefficients
+template <typename T>
+void modify_mpc_vec(
+    const std::span<T>& b, const std::span<T>& b_local,
+    const std::span<T>& b_local_copy,
+    const std::span<const std::int32_t>& cell_blocks, const int num_dofs,
+    const int bs, const std::vector<std::int8_t>& is_slave,
+    const std::span<const std::int32_t>& slaves,
+    const std::shared_ptr<const dolfinx::graph::AdjacencyList<std::int32_t>>&
+        masters,
+    const std::shared_ptr<const dolfinx::graph::AdjacencyList<T>>& coeffs)
+{
+
+  // NOTE: Should this be moved into the MPC constructor?
+  // Get local index of slaves in cell
+  std::vector<std::int32_t> local_index
+      = compute_local_slave_index(slaves, num_dofs, bs, cell_blocks, is_slave);
+
+  // Move contribution from each slave to corresponding master dof
+  for (std::size_t i = 0; i < local_index.size(); i++)
+  {
+    auto masters_i = masters->links(slaves[i]);
+    auto coeffs_i = coeffs->links(slaves[i]);
+    assert(masters_i.size() == coeffs_i.size());
+    for (std::size_t j = 0; j < masters_i.size(); j++)
+    {
+      if constexpr (std::is_scalar_v<T>)
+        // Use standard transpose for type double
+        b[masters_i[j]] += coeffs_i[j] * b_local_copy[local_index[i]];
+      else
+        // Use Hermitian transpose for type std::complex<double>
+        b[masters_i[j]] += std::conj(coeffs_i[j]) * b_local_copy[local_index[i]];
+      b_local[local_index[i]] = 0;
+    }
+  }
+}
 
 /// Assemble a linear form into a vector
 /// @param[in] b The vector to be assembled. It will not be zeroed before

--- a/cpp/assemble_vector.h
+++ b/cpp/assemble_vector.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Jorgen S. Dokken and Nathan Sime
+// Copyright (C) 2021 Jorgen S. Dokken, Nathan Sime, and Connor D. Pierce
 //
 // This file is part of DOLFINX_MPC
 //
@@ -17,48 +17,6 @@ namespace dolfinx_mpc
 template <typename T>
 class MultiPointConstraint;
 
-/// Given a local element vector, move all slave contributions to the global
-/// (local to process) vector.
-/// @param [in, out] b The global (local to process) vector
-/// @param [in, out] b_local The local element vector
-/// @param [in] b_local_copy Copy of the local element vector
-/// @param [in] cell_blocks Dofmap for the blocks in the cell
-/// @param [in] num_dofs The number of degrees of freedom in the local vector
-/// @param [in] bs The element block size
-/// @param [in] is_slave Vector indicating if a dof is a slave
-/// @param [in] slaves The slave dofs (local to process)
-/// @param [in] masters Adjacency list with master dofs
-/// @param [in] coeffs Adjacency list with the master coefficients
-template <typename T>
-void modify_mpc_vec(
-    const std::span<T>& b, const std::span<T>& b_local,
-    const std::span<T>& b_local_copy,
-    const std::span<const std::int32_t>& cell_blocks, const int num_dofs,
-    const int bs, const std::vector<std::int8_t>& is_slave,
-    const std::span<const std::int32_t>& slaves,
-    const std::shared_ptr<const dolfinx::graph::AdjacencyList<std::int32_t>>&
-        masters,
-    const std::shared_ptr<const dolfinx::graph::AdjacencyList<T>>& coeffs)
-{
-
-  // NOTE: Should this be moved into the MPC constructor?
-  // Get local index of slaves in cell
-  std::vector<std::int32_t> local_index
-      = compute_local_slave_index(slaves, num_dofs, bs, cell_blocks, is_slave);
-
-  // Move contribution from each slave to corresponding master dof
-  for (std::size_t i = 0; i < local_index.size(); i++)
-  {
-    auto masters_i = masters->links(slaves[i]);
-    auto coeffs_i = coeffs->links(slaves[i]);
-    assert(masters_i.size() == coeffs_i.size());
-    for (std::size_t j = 0; j < masters_i.size(); j++)
-    {
-      b[masters_i[j]] += coeffs_i[j] * b_local_copy[local_index[i]];
-      b_local[local_index[i]] = 0;
-    }
-  }
-}
 
 /// Assemble a linear form into a vector
 /// @param[in] b The vector to be assembled. It will not be zeroed before

--- a/python/dolfinx_mpc/utils/test.py
+++ b/python/dolfinx_mpc/utils/test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Jørgen Schartum Dokken
+# Copyright (C) 2021-2022 Jørgen Schartum Dokken and Connor D. Pierce
 #
 # This file is part of DOLFINX_MPC
 #

--- a/python/dolfinx_mpc/utils/test.py
+++ b/python/dolfinx_mpc/utils/test.py
@@ -222,7 +222,7 @@ def compare_mpc_lhs(A_org: PETSc.Mat, A_mpc: PETSc.Mat,
     glob_slaves = _gather_slaves_global(mpc)
     A_mpc_csr = gather_PETScMatrix(A_mpc, root=root)
     if MPI.COMM_WORLD.rank == root:
-        KTAK = K.T * A_csr * K
+        KTAK = np.conj(K.T) * A_csr * K
 
         # Remove identity rows of MPC matrix
         all_cols = np.arange(V.dofmap.index_map.size_global * V.dofmap.index_map_bs)
@@ -247,7 +247,7 @@ def compare_mpc_rhs(b_org: PETSc.Vec, b: PETSc.Vec, constraint: dolfinx_mpc.Mult
     # constants = gather_constants(constraint)
     comm = constraint.V.mesh.comm
     if comm.rank == root:
-        reduced_b = K.T @ b_org_np  # - constants for RHS mpc
+        reduced_b = np.conj(K.T) @ b_org_np  # - constants for RHS mpc
         all_cols = np.arange(constraint.V.dofmap.index_map.size_global * constraint.V.dofmap.index_map_bs)
         cols_except_slaves = np.flatnonzero(np.isin(all_cols, glob_slaves, invert=True).astype(np.int32))
         assert np.allclose(b_np[glob_slaves], 0)


### PR DESCRIPTION
# Summary

Fixes https://github.com/jorgensd/dolfinx_mpc/issues/35

# Changes

* README.md - add a note that the system is pre-multiplied by the Hermitian matrix in the complex case
* cpp/assemble_matrix.cpp - implement Hermitian pre-multiplication in `modify_mpc_cell`
* cpp/assemble_vector.h - implemented Hermitian pre-multiplication in `modify_mpc_vec`
* python/dolfinx_mpc/utils/test.py - use Hermitian pre-multiplication in `compare_mpc_lhs` and `compare_mpc_rhs`