### PR TITLE
avoid running sonar CI without secrets

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
+    # avoid running on pull requests from forks
+    # which don't have access to secrets
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     container: dolfinx/dev-env:nightly
     env:
       SONAR_SCANNER_VERSION:


### PR DESCRIPTION
skip running on pull requests from forks, which will always fail with missing credentials