### PR TITLE
Update cmake to 3.19

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -38,7 +38,7 @@ option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and install
 add_feature_info(CMAKE_INSTALL_RPATH_USE_LINK_PATH CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath.")
 
 # Check for required package DOLFINX
-find_package(DOLFINX 0.6.0...<1.0.0 REQUIRED)
+find_package(DOLFINX 0.6.0 REQUIRED)
 set_package_properties(DOLFINX PROPERTIES TYPE REQUIRED
     DESCRIPTION "New generation Dynamic Object-oriented Library for - FINite element computation"
     URL "https://github.com/FEniCS/dolfinx"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 # Top level CMakeLists.txt file for DOLFIN
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.19)
 
 #------------------------------------------------------------------------------
 # Set project name and version number
@@ -9,13 +9,7 @@ project(DOLFINX_MPC VERSION "0.5.1.0")
 #------------------------------------------------------------------------------
 # Set CMake options, see `cmake --help-policy CMP000x`
 
-cmake_policy(VERSION 3.10)
-if (POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-if (POLICY CMP0075)
-  cmake_policy(SET CMP0075 NEW)
-endif()
+cmake_policy(VERSION 3.19)
 
 #------------------------------------------------------------------------------
 # Use C++17
@@ -44,7 +38,7 @@ option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and install
 add_feature_info(CMAKE_INSTALL_RPATH_USE_LINK_PATH CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath.")
 
 # Check for required package DOLFINX
-find_package(DOLFINX 0.6.0 REQUIRED)
+find_package(DOLFINX 0.6.0...<1.0.0 REQUIRED)
 set_package_properties(DOLFINX PROPERTIES TYPE REQUIRED
     DESCRIPTION "New generation Dynamic Object-oriented Library for - FINite element computation"
     URL "https://github.com/FEniCS/dolfinx"
@@ -56,7 +50,7 @@ feature_summary(WHAT ALL)
 
 # Declare the library (target)
 
-add_library(dolfinx_mpc "")  # The "" is needed for older CMake. Remove later.
+add_library(dolfinx_mpc)
 
 # dolfinx gives us transitive dependency on mpi, petsc, basix, ufcx
 # without us needing to reimplement detection/dependency

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.19)
 
 PROJECT(dolfinx_mpc_pybind11)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -6,7 +6,8 @@ find_package(pybind11 REQUIRED CONFIG HINTS ${PYBIND11_DIR} ${PYBIND11_ROOT}
   $ENV{PYBIND11_DIR} $ENV{PYBIND11_ROOT})
 
 find_package(DOLFINX_MPC REQUIRED)
-find_package(Basix REQUIRED)
+MESSAGE(STATUS "Found dolfinx_mpc ${DOLFINX_MPC_VERSION}")
+MESSAGE(STATUS "Found dolfinx ${DOLFINX_VERSION}")
 
 # Set C++ standard before finding pybind11
 set(CMAKE_CXX_STANDARD 20)
@@ -18,9 +19,8 @@ pybind11_add_module(cpp SHARED
    dolfinx_mpc/mpc.cpp
    dolfinx_mpc/dolfinx_mpc.cpp)
 
-target_link_libraries(cpp PRIVATE pybind11::module dolfinx_mpc)
-target_link_libraries(cpp PUBLIC dolfinx)
-target_include_directories(cpp PUBLIC dolfinx)
+target_link_libraries(cpp PRIVATE pybind11::module)
+target_link_libraries(cpp PUBLIC dolfinx_mpc)
 
 # Get python include-dirs
 execute_process(
@@ -41,14 +41,6 @@ if (HAVE_PEDANTIC)
 endif()
 
 
-# Add to CMake search path
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
-
-# Add DOLFINX libraries and other config
-find_package(DOLFINX REQUIRED)
-if (DOLFINX_FOUND)
-   target_include_directories(cpp PRIVATE ${DOLFINX_INCLUDE_DIR})
-
 # Find petsc4py through python
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} -c "import petsc4py; print(petsc4py.get_include())"
@@ -58,6 +50,3 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 target_include_directories(cpp PRIVATE ${PETSC4PY_INCLUDE_DIR})
-
-endif()
-


### PR DESCRIPTION
- removes some workarounds for old cmake
- select dolfinx with range `[0.6.0...1.0.0)` (tested - this does accept 0.7.0 and reject 1.0.0)
- apply transitive-dependency simplification to python (removes several lookups, instead relying on `dolfinx_mpc` cpp target to find dolfinx, etc.)