### PR TITLE
API Change: Replace PETSc.Vec in python functions when possible

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container: dolfinx/dolfinx:v0.6.0-r1
+    container: ghcr.io/fenics/dolfinx/dolfinx:nightly
     env:
       # Directory that will be published on github pages
       PUBLISH_DIR: ./docs/_build/html

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -35,11 +35,11 @@ jobs:
           apt-get -y update
           apt-get install unzip
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,7 @@ jobs:
     # avoid running on pull requests from forks
     # which don't have access to secrets
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-    container: dolfinx/dolfinx:v0.6.0
+    container: ghcr.io/fenics/dolfinx/dolfinx:nightly
 
     env:
       SONAR_SCANNER_VERSION:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Cache SonarCloud packages
         uses: actions/cache@v3

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -91,7 +91,7 @@ jobs:
           coverage html --rcfile=.coveragerc
           coverage xml --rcfile=.coveragerc
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: code-coverage
           path: htmlcov

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -21,6 +21,7 @@ jobs:
 
     strategy:
       matrix:
+        build_mode: [Release, Debug]
         petsc_arch: [real, complex]
         # Due to: https://gitlab.com/petsc/petsc/-/issues/1288
         CXX: [c++]
@@ -49,7 +50,7 @@ jobs:
       OMPI_MCA_hwloc_base_binding_policy: none
       HDF5_MPI: "ON"
       HDF5_DIR: "/usr/local/"
-      MPC_BUILD_MODE: "Debug"
+      MPC_BUILD_MODE: ${{ matrix.build_mode }}
       MPC_CMAKE_CXX_FLAGS: "-Wall -Werror -g -pedantic -Ofast -march=native"
       PYTHONPATH: "/usr/local/dolfinx-${PETSC_TYPE}/lib/python3.10/dist-packages:/usr/local/lib"
       LD_LIBRARY_PATH: "/usr/local/petsc/${PETSC_ARCH}/lib/:/usr/local"

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -27,11 +27,11 @@ jobs:
         #, clang++]
         CC: [cc] 
         #, clang]
-        exclude:
-          - CC: cc
-            CXX: clang++
-          - CC: clang
-            CXX: c++
+        # exclude:
+        #   - CC: cc
+        #     CXX: clang++
+        #   - CC: clang
+        #     CXX: c++
     env:
       DOLFINX_BRANCH: "main"
       BASIX_BRANCH: "main"

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     runs-on: ubuntu-22.04
-    container: dolfinx/dev-env:v0.6.0
+    container: docker pull ghcr.io/fenics/test-env:nightly-mpich
 
     strategy:
       matrix:
@@ -53,6 +53,12 @@ jobs:
       DEB_PYTHON_INSTALL_LAYOUT: deb_system
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install clang
+        if: ${{ matrix.CC }} == "clang"
+        run: |
+          apt-get update
+          apt-get install -y clang
 
       - name: upgrade pip
         run: python3 -m pip install --upgrade setuptools pip

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -30,10 +30,10 @@ jobs:
           - CC: clang
             CXX: c++
     env:
-      DOLFINX_BRANCH: "v0.6.0"
-      BASIX_BRANCH: "v0.6.0"
-      UFL_BRANCH:  "2023.1.1.post0"
-      FFCX_BRANCH: "v0.6.0"
+      DOLFINX_BRANCH: "main"
+      BASIX_BRANCH: "main"
+      UFL_BRANCH:  "main"
+      FFCX_BRANCH: "main"
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
       PETSC_ARCH: "linux-gnu-${{ matrix.petsc_arch }}-32"

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -22,8 +22,11 @@ jobs:
     strategy:
       matrix:
         petsc_arch: [real, complex]
-        CXX: [c++, clang++]
-        CC: [cc, clang]
+        # Due to: https://gitlab.com/petsc/petsc/-/issues/1288
+        CXX: [c++]
+        #, clang++]
+        CC: [cc] 
+        #, clang]
         exclude:
           - CC: cc
             CXX: clang++

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     runs-on: ubuntu-22.04
-    container: docker pull ghcr.io/fenics/test-env:nightly-mpich
+    container: ghcr.io/fenics/test-env:nightly-mpich
 
     strategy:
       matrix:

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     container: ghcr.io/fenics/test-env:nightly-mpich
 
     strategy:

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
-    runs-on: ubuntu-22.04
+    runs-on: macos-latest
     container: ghcr.io/fenics/test-env:nightly-mpich
 
     strategy:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## main
-- No changes
+- Change input of `dolfinx_mpc.MultiPointConstraint.homogenize` and `dolfinx_mpc.backsubstitution` to `dolfinx.fem.Function` instead of `PETSc.Vec`.
 
 ## v0.6.1 (30.01.2023)
   - Fixes for CI

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.19)
 
 #------------------------------------------------------------------------------
 # Set project name and version number
-project(DOLFINX_MPC VERSION "0.6.1")
+project(DOLFINX_MPC VERSION "0.7.0.0")
 
 #------------------------------------------------------------------------------
 # Set CMake options, see `cmake --help-policy CMP000x`
@@ -38,7 +38,7 @@ option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and install
 add_feature_info(CMAKE_INSTALL_RPATH_USE_LINK_PATH CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath.")
 
 # Check for required package DOLFINX
-find_package(DOLFINX 0.6.0 REQUIRED)
+find_package(DOLFINX 0.7.0.0 REQUIRED)
 set_package_properties(DOLFINX PROPERTIES TYPE REQUIRED
     DESCRIPTION "New generation Dynamic Object-oriented Library for - FINite element computation"
     URL "https://github.com/FEniCS/dolfinx"

--- a/cpp/assemble_matrix.cpp
+++ b/cpp/assemble_matrix.cpp
@@ -226,7 +226,7 @@ void modify_mpc_cell(
     {
       col[0] = flattened_masters[1][j];
       A0[0] = coeff_i * flattened_coeffs[1][j]
-                * Ae_original(flattened_slaves[0][i], flattened_slaves[1][j]);
+              * Ae_original(flattened_slaves[0][i], flattened_slaves[1][j]);
       mat_set(row, col, A0);
     }
   }
@@ -395,7 +395,7 @@ void assemble_cells_impl(
     const std::function<int(const std::span<const std::int32_t>&,
                             const std::span<const std::int32_t>&,
                             const std::span<const T>)>& mat_add_values,
-    const dolfinx::mesh::Geometry& geometry,
+    const dolfinx::mesh::Geometry<double>& geometry,
     const std::vector<std::int32_t>& active_cells,
     std::function<void(std::span<T>, const std::span<const std::uint32_t>,
                        const std::int32_t, const int)>

--- a/python/benchmarks/bench_contact_3D.py
+++ b/python/benchmarks/bench_contact_3D.py
@@ -186,6 +186,7 @@ def demo_stacked_cubes(theta, ct, noslip, num_refinements, N0, timings=False):
     u_bc = Function(V)
     with u_bc.vector.localForm() as u_local:
         u_local.set(0.0)
+    u_bc.vector.destroy()
 
     bottom_dofs = locate_dofs_topological(V, fdim, mt.find(5))
     bc_bottom = dirichletbc(u_bc, bottom_dofs)

--- a/python/benchmarks/bench_elasticity.py
+++ b/python/benchmarks/bench_elasticity.py
@@ -41,6 +41,7 @@ def bench_elasticity_one(r_lvl: int = 0, out_hdf5: Optional[h5py.File] = None,
     u_bc = Function(V)
     with u_bc.vector.localForm() as u_local:
         u_local.set(0.0)
+    u_bc.vector.destroy()
 
     def boundaries(x):
         return np.isclose(x[0], np.finfo(float).eps)

--- a/python/benchmarks/bench_elasticity_edge.py
+++ b/python/benchmarks/bench_elasticity_edge.py
@@ -149,10 +149,10 @@ def bench_elasticity_edge(tetra: bool = True, r_lvl: int = 0, out_hdf5=None, xdm
 
     with Timer("~Elasticity: Solve problem") as timer:
         solver.setOperators(A)
-        uh = b.copy()
-        uh.set(0)
-        solver.solve(b, uh)
-        uh.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+        uh = Function(mpc.function_space)
+        uh.x.set(0)
+        solver.solve(b, uh.vector)
+        uh.x.scatter_forward()
         mpc.backsubstitution(uh)
         solver_time = timer.elapsed()
     if kspview:

--- a/python/benchmarks/bench_elasticity_edge.py
+++ b/python/benchmarks/bench_elasticity_edge.py
@@ -39,6 +39,7 @@ def bench_elasticity_edge(tetra: bool = True, r_lvl: int = 0, out_hdf5=None, xdm
     u_bc = Function(V)
     with u_bc.vector.localForm() as u_local:
         u_local.set(0.0)
+    u_bc.vector.destroy()
 
     def boundaries(x):
         return np.isclose(x[0], np.finfo(float).eps)

--- a/python/benchmarks/bench_periodic.py
+++ b/python/benchmarks/bench_periodic.py
@@ -137,12 +137,14 @@ def demo_periodic3D(tetra, r_lvl=0, out_hdf5=None,
     with Timer("~Periodic: Solve") as timer:
         # Create solver, set operator and options
         PETSc.Mat.setNearNullSpace(A, nullspace)
-        uh = b.copy()
+        uh = Function(mpc.function_space)
+        uh.x.set(0)
         solver.setFromOptions()
         solver.setOperators(A)
-        solver.solve(b, uh)
-        uh.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+        solver.solve(b, uh.vector)
+        uh.x.scatter_forward()
         mpc.backsubstitution(uh)
+
         solver_time = timer.elapsed()
         if kspview:
             solver.view()

--- a/python/benchmarks/ref_elasticity.py
+++ b/python/benchmarks/ref_elasticity.py
@@ -52,6 +52,7 @@ def ref_elasticity(tetra: bool = True, r_lvl: int = 0, out_hdf5: Optional[h5py.F
     u_bc = Function(V)
     with u_bc.vector.localForm() as u_local:
         u_local.set(0.0)
+    u_bc.vector.destroy()
 
     def boundaries(x):
         return np.isclose(x[0], np.finfo(float).eps)

--- a/python/demos/demo_contact_2D.py
+++ b/python/demos/demo_contact_2D.py
@@ -162,7 +162,7 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = True, quad:
 
         return self.u
 
-    LinearProblem.solve = patch_solve
+    LinearProblem.solve = patch_solve  # type: ignore
     problem = LinearProblem(a, rhs, mpc, bcs=bcs, petsc_options=petsc_options)
 
     # Build near nullspace

--- a/python/demos/demo_contact_2D.py
+++ b/python/demos/demo_contact_2D.py
@@ -18,9 +18,10 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 import numpy as np
 import scipy.sparse.linalg
 from dolfinx.common import Timer, TimingType, list_timings
-from dolfinx.fem import (Constant, VectorFunctionSpace, apply_lifting,
-                         assemble_matrix, assemble_vector, dirichletbc, form,
-                         locate_dofs_geometrical, set_bc)
+from dolfinx.fem import (Constant, VectorFunctionSpace,
+                         dirichletbc, form,
+                         locate_dofs_geometrical)
+from dolfinx.fem.petsc import assemble_matrix, assemble_vector, set_bc, apply_lifting
 from dolfinx.io import XDMFFile
 from dolfinx.log import LogLevel, set_log_level
 from dolfinx.mesh import locate_entities_boundary, meshtags
@@ -119,9 +120,9 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = True, quad:
         mpc.create_slip_constraint(V, (mtv, 6), tangent, bcs=bcs)
 
     mpc.finalize()
-    rtol = 1e-9
-    petsc_options = {"ksp_rtol": 1e-9,
-                     "pc_type": "gamg", "pc_gamg_type": "agg", "pc_gamg_square_graph": 2,
+    rtol = 3e-8
+    petsc_options = {"ksp_rtol": 1e-9, "ksp_atol": 1e-9, "pc_type": "gamg",
+                     "pc_gamg_type": "agg", "pc_gamg_square_graph": 2,
                      "pc_gamg_threshold": 0.02, "pc_gamg_coarse_eq_limit": 1000, "pc_gamg_sym_graph": True,
                      "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "jacobi",
                      "mg_levels_esteig_ksp_type": "cg"
@@ -129,6 +130,39 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = True, quad:
                      }
 
     # Solve Linear problem
+
+    def patch_solve(self):
+        import dolfinx_mpc
+        # Assemble lhs
+        self._A.zeroEntries()
+        dolfinx_mpc.assemble_matrix(self._a, self._mpc, bcs=self.bcs, A=self._A)
+        self._A.assemble()
+
+        # Temporary fix while:
+        # https://gitlab.com/petsc/petsc/-/issues/1339
+        # gets sorted
+        self._A.convert("baij", self._A)
+        self._A.convert("aij", self._A)
+        assert self._A.assembled
+
+        # Assemble rhs
+        with self._b.localForm() as b_loc:
+            b_loc.set(0)
+        dolfinx_mpc.assemble_vector(self._L, self._mpc, b=self._b)
+
+        # Apply boundary conditions to the rhs
+        dolfinx_mpc.apply_lifting(self._b, [self._a], [self.bcs], self._mpc)
+        self._b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+        set_bc(self._b, self.bcs)
+
+        # Solve linear system and update ghost values in the solution
+        self._solver.solve(self._b, self._x)
+        self.u.x.scatter_forward()
+        self._mpc.backsubstitution(self.u)
+
+        return self.u
+
+    LinearProblem.solve = patch_solve
     problem = LinearProblem(a, rhs, mpc, bcs=bcs, petsc_options=petsc_options)
 
     # Build near nullspace
@@ -182,8 +216,8 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = True, quad:
             d = scipy.sparse.linalg.spsolve(KTAK, reduced_L)
             # Back substitution to full solution vector
             uh_numpy = K @ d
-
-            assert np.allclose(uh_numpy, u_mpc, rtol=rtol)
+            assert np.allclose(uh_numpy, u_mpc, rtol=rtol, atol=rtol)
+    L_org.destroy()
 
 
 if __name__ == "__main__":

--- a/python/demos/demo_contact_3D.py
+++ b/python/demos/demo_contact_3D.py
@@ -149,8 +149,14 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = False, ct: 
 
     u_h = fem.Function(mpc.function_space)
     with Timer("~~Contact: Solve"):
+        # Temporary fix while:
+        # https://gitlab.com/petsc/petsc/-/issues/1339
+        # gets sorted
+        A.convert("baij", A)
+        A.convert("aij", A)
         solver.solve(b, u_h.vector)
         u_h.x.scatter_forward()
+
     with Timer("~~Contact: Backsubstitution"):
         mpc.backsubstitution(u_h)
 
@@ -165,12 +171,16 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = False, ct: 
         print(f"Norm of u {unorm:.5e}")
 
     # Write solution to file
-    u_h.name = f"u_{celltype}_{theta:.2f}{mesh_ext}{type_ext}".format(celltype, theta, type_ext, mesh_ext)
+    u_h.name = f"u_{celltype}_{theta:.2f}{mesh_ext}{type_ext}"
     outfile.write_mesh(mesh)
     outfile.write_function(u_h, 0.0, f"Xdmf/Domain/Grid[@Name='{mesh.name}'][1]")
+    outfile.close()
+
     # Solve the MPC problem using a global transformation matrix
     # and numpy solvers to get reference values
     if not compare:
+        b.destroy()
+        solver.destroy()
         return
 
     log_info("Solving reference problem with global matrix (using scipy)")
@@ -203,6 +213,9 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = False, ct: 
             assert np.allclose(uh_numpy, u_mpc)
 
     list_timings(mesh.comm, [TimingType.wall])
+    b.destroy()
+    L_org.destroy()
+    solver.destroy()
 
 
 if __name__ == "__main__":

--- a/python/demos/demo_contact_3D.py
+++ b/python/demos/demo_contact_3D.py
@@ -62,7 +62,7 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = False, ct: 
     # Define boundary conditions
 
     # Bottom boundary is fixed in all directions
-    bottom_dofs = fem.locate_dofs_topological(V, fdim, mt.find(5))  # type: ignore
+    bottom_dofs = fem.locate_dofs_topological(V, fdim, mt.find(5))
     u_bc = np.array((0, ) * mesh.geometry.dim, dtype=PETSc.ScalarType)
     bc_bottom = fem.dirichletbc(u_bc, bottom_dofs, V)
 
@@ -74,7 +74,7 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = False, ct: 
         # Top boundary has a given deformation normal to the interface
         g_vec = np.dot(r_matrix, g_vec)
 
-    top_dofs = fem.locate_dofs_topological(V, fdim, mt.find(3))  # type: ignore
+    top_dofs = fem.locate_dofs_topological(V, fdim, mt.find(3))
     bc_top = fem.dirichletbc(g_vec, top_dofs, V)
 
     bcs = [bc_bottom, bc_top]
@@ -152,7 +152,7 @@ def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = False, ct: 
         solver.solve(b, u_h.vector)
         u_h.x.scatter_forward()
     with Timer("~~Contact: Backsubstitution"):
-        mpc.backsubstitution(u_h.vector)
+        mpc.backsubstitution(u_h)
 
     it = solver.getIterationNumber()
     unorm = u_h.vector.norm()

--- a/python/demos/demo_elasticity_disconnect.py
+++ b/python/demos/demo_elasticity_disconnect.py
@@ -125,7 +125,8 @@ with mu.vector.localForm() as local:
 with lmbda.vector.localForm() as local:
     local.array[inner_dofs] = E_inner * nu_inner / ((1 + nu_inner) * (1 - 2 * nu_inner))
     local.array[outer_dofs] = E_outer * nu_outer / ((1 + nu_outer) * (1 - 2 * nu_outer))
-
+mu.vector.destroy()
+lmbda.vector.destroy()
 
 # Stress computation
 

--- a/python/demos/demo_elasticity_disconnect_2D.py
+++ b/python/demos/demo_elasticity_disconnect_2D.py
@@ -78,7 +78,8 @@ with mu.vector.localForm() as local:
 with lmbda.vector.localForm() as local:
     local.array[left_dofs] = E_left * nu_left / ((1 + nu_left) * (1 - 2 * nu_left))
     local.array[right_dofs] = E_right * nu_right / ((1 + nu_right) * (1 - 2 * nu_right))
-
+mu.vector.destroy()
+lmbda.vector.destroy()
 
 # Stress computation
 def sigma(v):

--- a/python/demos/demo_elasticity_disconnect_2D.py
+++ b/python/demos/demo_elasticity_disconnect_2D.py
@@ -82,6 +82,8 @@ mu.vector.destroy()
 lmbda.vector.destroy()
 
 # Stress computation
+
+
 def sigma(v):
     return (2.0 * mu * sym(grad(v))
             + lmbda * tr(sym(grad(v))) * Identity(len(v)))

--- a/python/demos/demo_periodic_geometrical.py
+++ b/python/demos/demo_periodic_geometrical.py
@@ -161,3 +161,4 @@ with Timer("~Demo: Verification"):
         uh_numpy = K @ d
         assert np.allclose(uh_numpy, u_mpc)
 list_timings(MPI.COMM_WORLD, [TimingType.wall])
+L_org.destroy()

--- a/python/demos/demo_periodic_gep.py
+++ b/python/demos/demo_periodic_gep.py
@@ -329,9 +329,9 @@ def assemble_and_solve(boundary_condition: List[str] = ["dirichlet", "periodic"]
     # update slave DoF
     for i in range(len(eigval)):
         eigvec_r[i].x.scatter_forward()
-        mpc.backsubstitution(eigvec_r[i].vector)
+        mpc.backsubstitution(eigvec_r[i])
         eigvec_i[i].x.scatter_forward()
-        mpc.backsubstitution(eigvec_i[i].vector)
+        mpc.backsubstitution(eigvec_i[i])
     print0(f"Computed eigenvalues:\n {np.around(eigval,decimals=2)}")
 
     # Save all eigenvectors

--- a/python/dolfinx_mpc/utils/mpc_utils.py
+++ b/python/dolfinx_mpc/utils/mpc_utils.py
@@ -41,7 +41,7 @@ def rotation_matrix(axis, angle):
     return np.sin(angle) * axis_x + identity + outer
 
 
-def facet_normal_approximation(V, mt: _cpp.mesh.MeshTags_int32, mt_id: int, tangent=False, jit_options: dict = {},
+def facet_normal_approximation(V, mt: _mesh.MeshTags, mt_id: int, tangent=False, jit_options: dict = {},
                                form_compiler_options: dict = {}):
     """
     Approximate the facet normal by projecting it into the function space for a set of facets
@@ -211,7 +211,7 @@ def determine_closest_block(V, point):
     boundary_cells = np.array(np.unique(boundary_cells), dtype=np.int32)
     boundary_cells = boundary_cells[boundary_cells < cell_imap.size_local]
     bb_tree = _geometry.BoundingBoxTree(V.mesh, tdim, boundary_cells)
-    midpoint_tree = _cpp.geometry.create_midpoint_tree(V.mesh, tdim, boundary_cells)
+    midpoint_tree = _geometry.create_midpoint_tree(V.mesh, tdim, boundary_cells)
 
     # Find facet closest
 
@@ -224,7 +224,8 @@ def determine_closest_block(V, point):
     else:
         # Get cell geometry
         p = V.mesh.geometry.x
-        entities = _cpp.mesh.entities_to_geometry(V.mesh, tdim, np.array([closest_cell], dtype=np.int32), False)
+        entities = _cpp.mesh.entities_to_geometry(
+            V.mesh._cpp_object, tdim, np.array([closest_cell], dtype=np.int32), False)
         R = np.linalg.norm(_cpp.geometry.compute_distance_gjk(point, p[entities[0]]))
 
     # Find processor with cell closest to point

--- a/python/dolfinx_mpc/utils/test.py
+++ b/python/dolfinx_mpc/utils/test.py
@@ -189,6 +189,8 @@ def gather_PETScVector(vector: PETSc.Vec, root=0) -> np.ndarray:
     Gather a PETScVector from different processors on
     process 'root' as an numpy array
     """
+    if vector.handle == 0:
+        raise RuntimeError("Vector has been destroyed prior to this call")
     numpy_vec = np.zeros(vector.size, dtype=vector.array.dtype)
     l_min = vector.owner_range[0]
     l_max = vector.owner_range[1]

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,13 +10,13 @@ from distutils.version import LooseVersion
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-if sys.version_info <= (3, 8):
+if sys.version_info < (3, 8):
     print("Python 3.8 or higher required, please upgrade.")
     sys.exit(1)
 
-VERSION = "0.6.1"
+VERSION = "0.7.0"
 
-REQUIREMENTS = ["numpy>=1.21", "fenics-dolfinx>=0.6.0.dev0"]
+REQUIREMENTS = ["numpy>=1.21", "fenics-dolfinx>0.6.0.dev0"]
 
 extras = {
     'docs': ['jupyter-book'],

--- a/python/tests/nitsche_ufl.py
+++ b/python/tests/nitsche_ufl.py
@@ -11,7 +11,6 @@ from dolfinx import fem as _fem
 from dolfinx import log as _log
 from dolfinx import mesh as dmesh
 from dolfinx import nls as _nls
-from dolfinx import cpp as _cpp
 from dolfinx_contact.helpers import (R_minus, epsilon, lame_parameters,
                                      rigid_motions_nullspace, sigma_func)
 from petsc4py import PETSc as _PETSc
@@ -19,7 +18,7 @@ from petsc4py import PETSc as _PETSc
 __all__ = ["nitsche_ufl"]
 
 
-def nitsche_ufl(mesh: dmesh.Mesh, mesh_data: Tuple[_cpp.mesh.MeshTags_int32, int, int],
+def nitsche_ufl(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.MeshTags, int, int],
                 physical_parameters: dict = {}, nitsche_parameters: Dict[str, float] = {},
                 plane_loc: float = 0.0, vertical_displacement: float = -0.1,
                 nitsche_bc: bool = True, quadrature_degree: int = 5, form_compiler_options: Dict = {},

--- a/python/tests/test_cube_contact.py
+++ b/python/tests/test_cube_contact.py
@@ -182,6 +182,7 @@ def test_cube_contact(generate_hex_boxes, nonslip, get_assemblers):  # noqa: F81
     u_bc = fem.Function(V)
     with u_bc.vector.localForm() as u_local:
         u_local.set(0.0)
+    u_bc.vector.destroy()
 
     bottom_dofs = fem.locate_dofs_topological(V, fdim, mt.find(5))
     bc_bottom = fem.dirichletbc(u_bc, bottom_dofs)

--- a/python/tests/test_cube_contact.py
+++ b/python/tests/test_cube_contact.py
@@ -288,7 +288,7 @@ def test_cube_contact(generate_hex_boxes, nonslip, get_assemblers):  # noqa: F81
         A_csr = dolfinx_mpc.utils.gather_PETScMatrix(A_org, root=root)
         K = dolfinx_mpc.utils.gather_transformation_matrix(mpc, root=root)
         L_np = dolfinx_mpc.utils.gather_PETScVector(L_org, root=root)
-        u_mpc = dolfinx_mpc.utils.gather_PETScVector(uh.vector, root=root)
+        u_mpc = dolfinx_mpc.utils.gather_PETScVector(u_vec, root=root)
 
         if MPI.COMM_WORLD.rank == root:
             KTAK = K.T * A_csr * K
@@ -298,5 +298,6 @@ def test_cube_contact(generate_hex_boxes, nonslip, get_assemblers):  # noqa: F81
             # Back substitution to full solution vector
             uh_numpy = K @ d
             assert np.allclose(uh_numpy, u_mpc)
-    u_vec.destroy()
+    L_org.destroy()
+
     list_timings(comm, [TimingType.wall])

--- a/python/tests/test_cube_contact.py
+++ b/python/tests/test_cube_contact.py
@@ -259,22 +259,13 @@ def test_cube_contact(generate_hex_boxes, nonslip, get_assemblers):  # noqa: F81
 
     with Timer("~MPC: Solve"):
         solver.setOperators(A)
-        uh = b.copy()
-        uh.set(0)
-        solver.solve(b, uh)
+        uh = fem.Function(mpc.function_space)
+        uh.x.set(0)
+        u_vec = uh.vector
+        solver.solve(b, u_vec)
 
-    uh.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+    u_vec.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
     mpc.backsubstitution(uh)
-
-    # Write solution to file
-    # u_h = fem.Function(mpc.function_space)
-    # u_h.vector.setArray(uh.array)
-    # u_h.x.scatter_forward()
-    # u_h.name = "u_{0:.2f}".format(theta)
-    # import dolfinx.io as io
-    # with io.XDMFFile(comm, "output/rotated_cube3D.xdmf", "w") as outfile:
-    #     outfile.write_mesh(mesh)
-    #     outfile.write_function(u_h, 0.0, f"Xdmf/Domain/Grid[@Name='{mesh.name}'][1]")
 
     # Solve the MPC problem using a global transformation matrix
     # and numpy solvers to get reference values
@@ -296,7 +287,7 @@ def test_cube_contact(generate_hex_boxes, nonslip, get_assemblers):  # noqa: F81
         A_csr = dolfinx_mpc.utils.gather_PETScMatrix(A_org, root=root)
         K = dolfinx_mpc.utils.gather_transformation_matrix(mpc, root=root)
         L_np = dolfinx_mpc.utils.gather_PETScVector(L_org, root=root)
-        u_mpc = dolfinx_mpc.utils.gather_PETScVector(uh, root=root)
+        u_mpc = dolfinx_mpc.utils.gather_PETScVector(uh.vector, root=root)
 
         if MPI.COMM_WORLD.rank == root:
             KTAK = K.T * A_csr * K
@@ -306,5 +297,5 @@ def test_cube_contact(generate_hex_boxes, nonslip, get_assemblers):  # noqa: F81
             # Back substitution to full solution vector
             uh_numpy = K @ d
             assert np.allclose(uh_numpy, u_mpc)
-
+    u_vec.destroy()
     list_timings(comm, [TimingType.wall])

--- a/python/tests/test_integration_domains.py
+++ b/python/tests/test_integration_domains.py
@@ -90,7 +90,7 @@ def test_cell_domains(get_assemblers):  # noqa: F811
     uh = fem.Function(mpc.function_space)
     uh.x.set(0)
     solver.solve(b, uh.vector)
-    uh.x.scatter_reverse(la.ScatterMode.add)
+    uh.x.scatter_forward()
     mpc.backsubstitution(uh)
 
     root = 0

--- a/python/tests/test_integration_domains.py
+++ b/python/tests/test_integration_domains.py
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier:    MIT
 
 
-import dolfinx.fem as fem
-import dolfinx.la as la
+from dolfinx import fem
 import dolfinx_mpc
 import numpy as np
 import pytest

--- a/python/tests/test_lifting.py
+++ b/python/tests/test_lifting.py
@@ -46,6 +46,7 @@ def test_lifting(get_assemblers):  # noqa: F811
     u_bc = fem.Function(V)
     with u_bc.vector.localForm() as u_local:
         u_local.set(2.3)
+    u_bc.vector.destroy()
 
     def dirichletboundary(x):
         return np.isclose(x[0], 1)
@@ -88,7 +89,7 @@ def test_lifting(get_assemblers):  # noqa: F811
     uh = fem.Function(mpc.function_space)
     uh.x.set(0)
     solver.solve(b, uh.vector)
-    uh.x.scatter_reverse(la.ScatterMode.add)
+    uh.x.scatter_forward()
     mpc.backsubstitution(uh)
 
     root = 0

--- a/python/tests/test_lifting.py
+++ b/python/tests/test_lifting.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier:    MIT
 
-from dolfinx import la, fem
+from dolfinx import fem
 import dolfinx_mpc
 import dolfinx_mpc.utils
 import numpy as np

--- a/python/tests/test_nonlinear_assembly.py
+++ b/python/tests/test_nonlinear_assembly.py
@@ -113,6 +113,7 @@ def test_nonlinear_possion(poly_order):
         u_bc = dolfinx.fem.Function(V)
         with u_bc.vector.localForm() as u_local:
             u_local.set(0.0)
+        u_bc.vector.destroy()
 
         facets = dolfinx.mesh.locate_entities_boundary(mesh, 1, boundary)
         topological_dofs = dolfinx.fem.locate_dofs_topological(V, 1, facets)
@@ -218,3 +219,4 @@ def test_homogenize(element, poly_order):
                 assert np.isclose(u_.array_r[i], 0.0)
             else:
                 assert np.isclose(u_.array_r[i], 1.0)
+    u.vector.destroy()

--- a/python/tests/test_nonlinear_assembly.py
+++ b/python/tests/test_nonlinear_assembly.py
@@ -66,8 +66,8 @@ class NewtonSolverMPC(dolfinx.cpp.nls.petsc.NewtonSolver):
         self.u_mpc.vector.axpy(-1.0, dx)
         self.u_mpc.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT,
                                       mode=PETSc.ScatterMode.FORWARD)
-        self.mpc.homogenize(self.u_mpc.vector)
-        self.mpc.backsubstitution(self.u_mpc.vector)
+        self.mpc.homogenize(self.u_mpc)
+        self.mpc.backsubstitution(self.u_mpc)
         x.array = self.u_mpc.vector.array_r
         x.ghostUpdate(addv=PETSc.InsertMode.INSERT,
                       mode=PETSc.ScatterMode.FORWARD)
@@ -210,7 +210,7 @@ def test_homogenize(element, poly_order):
     assert np.isclose(u.vector.min()[1], u.vector.max()[1])
     assert np.isclose(u.vector.array_r[0], 1.0)
 
-    mpc.homogenize(u.vector)
+    mpc.homogenize(u)
 
     with u.vector.localForm() as u_:
         for i in range(V.dofmap.index_map.size_local * V.dofmap.index_map_bs):

--- a/python/tests/test_rectangular_assembly.py
+++ b/python/tests/test_rectangular_assembly.py
@@ -131,7 +131,7 @@ def test_mixed_element(cell_type, ghost_mode):
 
     bcs = [bc1]
 
-    V, V_to_W = W.sub(0).collapse()
+    V, _ = W.sub(0).collapse()
     mpc_vq = dolfinx_mpc.MultiPointConstraint(W)
     n_approx = dolfinx_mpc.utils.create_normal_approximation(V, mt, 1)
     mpc_vq.create_slip_constraint(W.sub(0), (mt, 1), n_approx, bcs=bcs)
@@ -190,3 +190,9 @@ def test_mixed_element(cell_type, ghost_mode):
 
     # -- Ensure monolithic and nest matrices are the same
     assert np.isclose(nest_matrix_norm(A_nest), A.norm())
+    for b_sub in b_nest.getNestSubVecs():
+        b_sub.destroy()
+    b_nest.destroy()
+    for b_sub in b_org_nest.getNestSubVecs():
+        b_sub.destroy()
+    b_org_nest.destroy()

--- a/python/tests/test_surface_integral.py
+++ b/python/tests/test_surface_integral.py
@@ -133,7 +133,8 @@ def test_surface_integrals(get_assemblers):  # noqa: F811
             # Back substitution to full solution vector
             uh_numpy = K @ d
             assert np.allclose(uh_numpy, u_mpc)
-
+    L_org.destroy()
+    b.destroy()
     list_timings(comm, [TimingType.wall])
 
 
@@ -200,5 +201,6 @@ def test_surface_integral_dependency(get_assemblers):  # noqa: F811
     with Timer("~TEST: Compare"):
         dolfinx_mpc.utils.compare_mpc_lhs(A_org, A, mpc, root=root)
         dolfinx_mpc.utils.compare_mpc_rhs(L_org, b, mpc, root=root)
-
+    L_org.destroy()
+    b.destroy()
     list_timings(comm, [TimingType.wall])

--- a/python/tests/test_surface_integral.py
+++ b/python/tests/test_surface_integral.py
@@ -38,6 +38,8 @@ def test_surface_integrals(get_assemblers):  # noqa: F811
     u_bc = fem.Function(V)
     with u_bc.vector.localForm() as u_local:
         u_local.set(0.0)
+    u_bc.vector.destroy()
+
     bc = fem.dirichletbc(u_bc, bc_dofs)
     bcs = [bc]
 

--- a/python/tests/test_vector_poisson.py
+++ b/python/tests/test_vector_poisson.py
@@ -77,11 +77,11 @@ def test_vector_possion(Nx, Ny, slave_space, master_space, get_assemblers):  # n
     fem.petsc.set_bc(b, bcs)
 
     solver.setOperators(A)
-    uh = b.copy()
-    uh.set(0)
+    uh = fem.Function(mpc.function_space)
+    uh.x.set(0)
 
-    solver.solve(b, uh)
-    uh.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+    solver.solve(b, uh.vector)
+    uh.x.scatter_forward()
     mpc.backsubstitution(uh)
 
     # Generate reference matrices for unconstrained problem
@@ -103,7 +103,7 @@ def test_vector_possion(Nx, Ny, slave_space, master_space, get_assemblers):  # n
         A_csr = dolfinx_mpc.utils.gather_PETScMatrix(A_org, root=root)
         K = dolfinx_mpc.utils.gather_transformation_matrix(mpc, root=root)
         L_np = dolfinx_mpc.utils.gather_PETScVector(L_org, root=root)
-        u_mpc = dolfinx_mpc.utils.gather_PETScVector(uh, root=root)
+        u_mpc = dolfinx_mpc.utils.gather_PETScVector(uh.vector, root=root)
 
         if MPI.COMM_WORLD.rank == root:
             KTAK = K.T * A_csr * K

--- a/python/tests/test_vector_poisson.py
+++ b/python/tests/test_vector_poisson.py
@@ -114,5 +114,6 @@ def test_vector_possion(Nx, Ny, slave_space, master_space, get_assemblers):  # n
             # Back substitution to full solution vector
             uh_numpy = K @ d
             assert np.allclose(uh_numpy, u_mpc)
-
+    b.destroy()
+    L_org.destroy()
     list_timings(comm, [TimingType.wall])

--- a/python/tests/test_vector_poisson.py
+++ b/python/tests/test_vector_poisson.py
@@ -38,6 +38,7 @@ def test_vector_possion(Nx, Ny, slave_space, master_space, get_assemblers):  # n
     u_bc = fem.Function(V)
     with u_bc.vector.localForm() as u_local:
         u_local.set(0.0)
+    u_bc.vector.destroy()
 
     bdofsV = fem.locate_dofs_geometrical(V, boundary)
     bc = fem.dirichletbc(u_bc, bdofsV)


### PR DESCRIPTION
- Change input to `backsubstitute` and `homogenize` to be DOLFINx functions.

Justification is avoid usage of PETSc vectors, as the garbage collection in Python is complicated and error prone.