### PR TITLE
remove unused DOLFINX_MPC_CXX_COMPILER variable

### DIFF
--- a/cpp/DOLFINX_MPCConfig.cmake.in
+++ b/cpp/DOLFINX_MPCConfig.cmake.in
@@ -3,9 +3,6 @@
 
 @PACKAGE_INIT@
 
-# Compilers
-set_and_check(DOLFINX_MPC_CXX_COMPILER "@CMAKE_CXX_COMPILER@")
-
 include(CMakeFindDependencyMacro)
 find_dependency(DOLFINX REQUIRED)
 find_dependency(MPI REQUIRED)


### PR DESCRIPTION
cause FindLibrary(DOLFINX_MPC) to fail if the original compiler is not at the same path (e.g. conda), even if it's unused.