### PR TITLE
Quality of life updates and sync with DOLFINx main branch

### DIFF
--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -119,8 +119,6 @@ jobs:
 
       - name: Run demos (serial)
         run: |
-          mkdir -p meshes
-          mkdir -p results
           coverage run --rcfile=.coveragerc python/demos/demo_elasticity.py
           coverage run --rcfile=.coveragerc python/demos/demo_periodic_geometrical.py
           coverage run --rcfile=.coveragerc python/demos/demo_stokes.py

--- a/python/benchmarks/bench_elasticity.py
+++ b/python/benchmarks/bench_elasticity.py
@@ -6,6 +6,7 @@
 
 import resource
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from pathlib import Path
 from typing import Optional
 
 import h5py
@@ -16,7 +17,6 @@ from dolfinx.fem import (Constant, Function, VectorFunctionSpace, dirichletbc,
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (create_unit_cube, locate_entities_boundary, meshtags,
                           refine)
-from dolfinx_mpc.utils import log_info, rigid_motions_nullspace
 from mpi4py import MPI
 from petsc4py import PETSc
 from ufl import (Identity, TestFunction, TrialFunction, ds, dx, grad, inner,
@@ -24,6 +24,7 @@ from ufl import (Identity, TestFunction, TrialFunction, ds, dx, grad, inner,
 
 from dolfinx_mpc import (MultiPointConstraint, apply_lifting, assemble_matrix,
                          assemble_vector)
+from dolfinx_mpc.utils import log_info, rigid_motions_nullspace
 
 
 def bench_elasticity_one(r_lvl: int = 0, out_hdf5: Optional[h5py.File] = None,
@@ -161,8 +162,9 @@ def bench_elasticity_one(r_lvl: int = 0, out_hdf5: Optional[h5py.File] = None,
         u_h = Function(mpc.function_space)
         u_h.vector.setArray(uh.array)
         u_h.name = "u_mpc"
-
-        fname = f"results/bench_elasticity_{r_lvl}.xdmf"
+        outdir = Path("results")
+        outdir.mkdir(exist_ok=True, parents=True)
+        fname = outdir / f"bench_elasticity_{r_lvl}.xdmf"
         with XDMFFile(MPI.COMM_WORLD, fname, "w") as outfile:
             outfile.write_mesh(mesh)
             outfile.write_function(u_h)

--- a/python/benchmarks/ref_elasticity.py
+++ b/python/benchmarks/ref_elasticity.py
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier:    MIT
 
-
 import resource
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from pathlib import Path
 from time import perf_counter
 from typing import Optional
 
@@ -21,11 +21,12 @@ from dolfinx.io import XDMFFile
 from dolfinx.log import LogLevel, log, set_log_level
 from dolfinx.mesh import (CellType, create_unit_cube, locate_entities_boundary,
                           meshtags, refine)
-from dolfinx_mpc.utils import rigid_motions_nullspace
 from mpi4py import MPI
 from petsc4py import PETSc
 from ufl import (Identity, SpatialCoordinate, TestFunction, TrialFunction,
                  as_vector, ds, dx, grad, inner, sym, tr)
+
+from dolfinx_mpc.utils import rigid_motions_nullspace
 
 
 def ref_elasticity(tetra: bool = True, r_lvl: int = 0, out_hdf5: Optional[h5py.File] = None,
@@ -169,7 +170,10 @@ def ref_elasticity(tetra: bool = True, r_lvl: int = 0, out_hdf5: Optional[h5py.F
 
         # Name formatting of functions
         u_.name = "u_unconstrained"
-        fname = "results/ref_elasticity_{0:d}.xdmf".format(r_lvl)
+        outdir = Path("results")
+        outdir.mkdir(exist_ok=True, parents=True)
+
+        fname = outdir / "ref_elasticity_{0:d}.xdmf".format(r_lvl)
         with XDMFFile(MPI.COMM_WORLD, fname, "w") as out_xdmf:
             out_xdmf.write_mesh(mesh)
             out_xdmf.write_function(u_, 0.0, "Xdmf/Domain/Grid[@Name='{0:s}'][1]".format(mesh.name))

--- a/python/benchmarks/ref_periodic.py
+++ b/python/benchmarks/ref_periodic.py
@@ -18,6 +18,7 @@
 
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from pathlib import Path
 from time import perf_counter
 from typing import Optional
 
@@ -151,7 +152,9 @@ def reference_periodic(tetra: bool, r_lvl: int = 0, out_hdf5: Optional[h5py.File
     # Output solution to XDMF
     if xdmf:
         ext = "tet" if tetra else "hex"
-        fname = "results/reference_periodic_{0:d}_{1:s}.xdmf".format(
+        outdir = Path("results")
+        outdir.mkdir(exist_ok=True, parents=True)
+        fname = outdir / "reference_periodic_{0:d}_{1:s}.xdmf".format(
             r_lvl, ext)
         u_.name = "u_" + ext + "_unconstrained"
         with XDMFFile(MPI.COMM_WORLD, fname, "w") as out_periodic:

--- a/python/demos/create_and_export_mesh.py
+++ b/python/demos/create_and_export_mesh.py
@@ -174,7 +174,8 @@ def generate_tet_boxes(x0: float, y0: float, z0: float, x1: float, y1: float, z1
 
 
 def generate_hex_boxes(x0: float, y0: float, z0: float, x1: float, y1: float, z1: float, z2: float, res: float,
-                       facet_markers: Sequence[Sequence[int]], volume_markers: Sequence[int], verbose: bool = False) -> Tuple[_mesh.Mesh, _mesh.MeshTags]:
+                       facet_markers: Sequence[Sequence[int]], volume_markers: Sequence[int],
+                       verbose: bool = False) -> Tuple[_mesh.Mesh, _mesh.MeshTags]:
     """
     Generate the stacked boxes [x0,y0,z0]x[y1,y1,z1] and
     [x0,y0,z1] x [x1,y1,z2] with different resolution in each box.

--- a/python/demos/create_and_export_mesh.py
+++ b/python/demos/create_and_export_mesh.py
@@ -1,15 +1,17 @@
-from typing import Dict, List, Sequence, Tuple
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple, Union
 
 import dolfinx.common as _common
 import dolfinx.cpp as _cpp
 import dolfinx.io as _io
 import dolfinx.mesh as _mesh
-import dolfinx_mpc.utils as _utils
 import gmsh
 import numpy as np
 import ufl
 from dolfinx.io import gmshio
 from mpi4py import MPI
+
+import dolfinx_mpc.utils as _utils
 
 
 def gmsh_3D_stacked(celltype: str, theta: float, res: float = 0.1,
@@ -172,7 +174,7 @@ def generate_tet_boxes(x0: float, y0: float, z0: float, x1: float, y1: float, z1
 
 
 def generate_hex_boxes(x0: float, y0: float, z0: float, x1: float, y1: float, z1: float, z2: float, res: float,
-                       facet_markers: Sequence[Sequence[int]], volume_markers: Sequence[int], verbose: bool = False):
+                       facet_markers: Sequence[Sequence[int]], volume_markers: Sequence[int], verbose: bool = False) -> Tuple[_mesh.Mesh, _mesh.MeshTags]:
     """
     Generate the stacked boxes [x0,y0,z0]x[y1,y1,z1] and
     [x0,y0,z1] x [x1,y1,z2] with different resolution in each box.
@@ -221,7 +223,7 @@ def generate_hex_boxes(x0: float, y0: float, z0: float, x1: float, y1: float, z1
     return mesh, ft
 
 
-def gmsh_2D_stacked(celltype: str, theta: float, verbose: bool = False):
+def gmsh_2D_stacked(celltype: str, theta: float, verbose: bool = False) -> Tuple[_mesh.Mesh, _mesh.MeshTags]:
     res = 0.1
     x0, y0, z0 = 0, 0, 0
     x1, y1 = 1, 1
@@ -334,7 +336,7 @@ def gmsh_2D_stacked(celltype: str, theta: float, verbose: bool = False):
     return mesh, ft
 
 
-def mesh_2D_dolfin(celltype: str, theta: float = 0):
+def mesh_2D_dolfin(celltype: str, theta: float = 0, outdir: Union[str, Path] = Path("meshes")):
     """
     Create two 2D cubes stacked on top of each other,
     and the corresponding mesh markers using dolfin built-in meshes
@@ -448,7 +450,9 @@ def mesh_2D_dolfin(celltype: str, theta: float = 0):
         arg_sort = np.argsort(np.hstack(all_indices))
         mt = _mesh.meshtags(mesh, fdim, np.hstack(all_indices)[arg_sort], np.hstack(all_values)[arg_sort])
         mt.name = "facet_tags"
-        with _io.XDMFFile(MPI.COMM_SELF, f"meshes/mesh_{celltype}_{theta:.2f}.xdmf", "w") as o_f:
+        outpath = Path(outdir)
+        outpath.mkdir(exist_ok=True, parents=True)
+        with _io.XDMFFile(MPI.COMM_SELF, outpath / f"mesh_{celltype}_{theta:.2f}.xdmf", "w") as o_f:
             o_f.write_mesh(mesh)
             o_f.write_meshtags(ct, x=mesh.geometry)
             o_f.write_meshtags(mt, x=mesh.geometry)
@@ -456,7 +460,7 @@ def mesh_2D_dolfin(celltype: str, theta: float = 0):
 
 
 def mesh_3D_dolfin(theta: float = 0, ct: _mesh.CellType = _mesh.CellType.tetrahedron,
-                   ext: str = "tetrahedron", res: float = 0.1):
+                   ext: str = "tetrahedron", res: float = 0.1, outdir: Union[str, Path] = Path("meshes")):
     timer = _common.Timer("~~Contact: Create mesh")
 
     def find_plane_function(p0, p1, p2):
@@ -573,7 +577,9 @@ def mesh_3D_dolfin(theta: float = 0, ct: _mesh.CellType = _mesh.CellType.tetrahe
         sorted_indices = np.asarray(np.hstack(all_indices)[arg_sort], dtype=np.int32)
         mt = _mesh.meshtags(mesh, fdim, sorted_indices, sorted_vals)
         mt.name = "facet_tags"
-        fname = f"meshes/mesh_{ext}_{theta:.2f}.xdmf"
+        outpath = Path(outdir)
+        outpath.mkdir(exist_ok=True, parents=True)
+        fname = outpath / f"mesh_{ext}_{theta:.2f}.xdmf"
 
         with _io.XDMFFile(MPI.COMM_SELF, fname, "w") as o_f:
             o_f.write_mesh(mesh)

--- a/python/demos/demo_contact_3D.py
+++ b/python/demos/demo_contact_3D.py
@@ -9,13 +9,19 @@
 
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from pathlib import Path
 
 import dolfinx.fem as fem
 import numpy as np
 import scipy.sparse.linalg
+from create_and_export_mesh import gmsh_3D_stacked, mesh_3D_dolfin
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import CellType
+from mpi4py import MPI
+from petsc4py import PETSc
+from ufl import Identity, TestFunction, TrialFunction, dx, grad, inner, sym, tr
+
 from dolfinx_mpc import (MultiPointConstraint, apply_lifting, assemble_matrix,
                          assemble_vector)
 from dolfinx_mpc.utils import (compare_mpc_lhs, compare_mpc_rhs,
@@ -23,11 +29,6 @@ from dolfinx_mpc.utils import (compare_mpc_lhs, compare_mpc_rhs,
                                gather_PETScVector,
                                gather_transformation_matrix, log_info,
                                rigid_motions_nullspace, rotation_matrix)
-from mpi4py import MPI
-from petsc4py import PETSc
-from ufl import Identity, TestFunction, TrialFunction, dx, grad, inner, sym, tr
-
-from create_and_export_mesh import gmsh_3D_stacked, mesh_3D_dolfin
 
 
 def demo_stacked_cubes(outfile: XDMFFile, theta: float, gmsh: bool = False, ct: CellType = CellType.tetrahedron,
@@ -240,8 +241,9 @@ if __name__ == "__main__":
                       help="List timings", default=False)
 
     args = parser.parse_args()
-
-    outfile = XDMFFile(MPI.COMM_WORLD, "results/demo_contact_3D.xdmf", "w")
+    outdir = Path("results")
+    outdir.mkdir(exist_ok=True, parents=True)
+    outfile = XDMFFile(MPI.COMM_WORLD, results / "demo_contact_3D.xdmf", "w")
 
     ct = CellType.hexahedron if args.hex else CellType.tetrahedron
 

--- a/python/demos/demo_contact_3D.py
+++ b/python/demos/demo_contact_3D.py
@@ -243,7 +243,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     outdir = Path("results")
     outdir.mkdir(exist_ok=True, parents=True)
-    outfile = XDMFFile(MPI.COMM_WORLD, results / "demo_contact_3D.xdmf", "w")
+    outfile = XDMFFile(MPI.COMM_WORLD, outdir / "demo_contact_3D.xdmf", "w")
 
     ct = CellType.hexahedron if args.hex else CellType.tetrahedron
 

--- a/python/demos/demo_elasticity.py
+++ b/python/demos/demo_elasticity.py
@@ -3,21 +3,21 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
-
+from pathlib import Path
 
 import dolfinx.fem as fem
-import dolfinx_mpc.utils
 import numpy as np
 import scipy.sparse.linalg
-
 from dolfinx.common import Timer
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import create_unit_square, locate_entities_boundary
-from dolfinx_mpc import (MultiPointConstraint, LinearProblem)
 from mpi4py import MPI
 from petsc4py import PETSc
 from ufl import (Identity, SpatialCoordinate, TestFunction, TrialFunction,
                  as_vector, dx, grad, inner, sym, tr)
+
+import dolfinx_mpc.utils
+from dolfinx_mpc import LinearProblem, MultiPointConstraint
 
 
 def demo_elasticity():
@@ -69,7 +69,10 @@ def demo_elasticity():
     problem = LinearProblem(a, rhs, mpc, bcs=bcs, petsc_options=petsc_options)
     u_h = problem.solve()
     u_h.name = "u_mpc"
-    with XDMFFile(MPI.COMM_WORLD, "results/demo_elasticity.xdmf", "w") as outfile:
+    outdir = Path("results")
+    outdir.mkdir(exist_ok=True, parents=True)
+
+    with XDMFFile(MPI.COMM_WORLD, outdir / "demo_elasticity.xdmf", "w") as outfile:
         outfile.write_mesh(mesh)
         outfile.write_function(u_h)
 
@@ -92,7 +95,7 @@ def demo_elasticity():
     u_.x.scatter_forward()
     u_.name = "u_unconstrained"
 
-    with XDMFFile(MPI.COMM_WORLD, "results/demo_elasticity.xdmf", "a") as outfile:
+    with XDMFFile(MPI.COMM_WORLD, outdir / "demo_elasticity.xdmf", "a") as outfile:
         outfile.write_function(u_)
         outfile.close()
 

--- a/python/demos/demo_elasticity_disconnect_2D.py
+++ b/python/demos/demo_elasticity_disconnect_2D.py
@@ -6,6 +6,7 @@
 #
 # Create constraint between two bodies that are not in contact
 
+from pathlib import Path
 
 import gmsh
 import numpy as np
@@ -14,13 +15,14 @@ from dolfinx.fem import (Constant, Function, FunctionSpace,
                          locate_dofs_geometrical, locate_dofs_topological)
 from dolfinx.io import XDMFFile, gmshio
 from dolfinx.mesh import locate_entities_boundary
-from dolfinx_mpc import LinearProblem, MultiPointConstraint
-from dolfinx_mpc.utils import (create_point_to_point_constraint,
-                               rigid_motions_nullspace)
 from mpi4py import MPI
 from petsc4py import PETSc
 from ufl import (Identity, Measure, SpatialCoordinate, TestFunction,
                  TrialFunction, grad, inner, sym, tr)
+
+from dolfinx_mpc import LinearProblem, MultiPointConstraint
+from dolfinx_mpc.utils import (create_point_to_point_constraint,
+                               rigid_motions_nullspace)
 
 # Mesh parameters for creating a mesh consisting of two disjoint rectangles
 right_tag = 1
@@ -184,6 +186,8 @@ if MPI.COMM_WORLD.rank == 0:
 
 # Write solution to file
 u_h.name = "u"
-with XDMFFile(MPI.COMM_WORLD, "results/demo_elasticity_disconnect_2D.xdmf", "w") as xdmf:
+outdir = Path("results")
+outdir.mkdir(exist_ok=True, parents=True)
+with XDMFFile(MPI.COMM_WORLD, outdir / "demo_elasticity_disconnect_2D.xdmf", "w") as xdmf:
     xdmf.write_mesh(mesh)
     xdmf.write_function(u_h)

--- a/python/demos/demo_periodic3d_topological.py
+++ b/python/demos/demo_periodic3d_topological.py
@@ -16,22 +16,24 @@
 #
 # SPDX-License-Identifier:    MIT
 
+from pathlib import Path
 from typing import Dict, Union
 
 import dolfinx.fem as fem
-import dolfinx_mpc.utils
 import numpy as np
 import scipy.sparse.linalg
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.io import VTXWriter
 from dolfinx.mesh import (CellType, create_unit_cube, locate_entities_boundary,
                           meshtags)
-from dolfinx_mpc import LinearProblem
 from mpi4py import MPI
 from numpy.typing import NDArray
 from petsc4py import PETSc
 from ufl import (SpatialCoordinate, TestFunction, TrialFunction, as_vector, dx,
                  exp, grad, inner, pi, sin)
+
+import dolfinx_mpc.utils
+from dolfinx_mpc import LinearProblem
 
 # Get PETSc int and scalar types
 complex_mode = True if np.dtype(PETSc.ScalarType).kind == 'c' else False
@@ -125,7 +127,9 @@ def demo_periodic3D(celltype: CellType):
     assert old_local == mpc_local
     u_out.x.array[:old_local + old_ghosts] = u_h.x.array[:mpc_local + old_ghosts]
     u_out.name = "u_" + ext
-    fname = f"results/demo_periodic3d_{ext}.bp"
+    outdir = Path("results")
+    outdir.mkdir(exist_ok=True, parents=True)
+    fname = outdir / f"demo_periodic3d_{ext}.bp"
     out_periodic = VTXWriter(MPI.COMM_WORLD, fname, u_out)
     out_periodic.write(0)
     out_periodic.close()

--- a/python/demos/demo_periodic_geometrical.py
+++ b/python/demos/demo_periodic_geometrical.py
@@ -12,19 +12,22 @@
 # SPDX-License-Identifier:    MIT
 
 
+from pathlib import Path
 from typing import Union
+
 import dolfinx.fem as fem
-import dolfinx_mpc.utils
 import numpy as np
 import scipy.sparse.linalg
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import create_unit_square, locate_entities_boundary
-from dolfinx_mpc import LinearProblem, MultiPointConstraint
 from mpi4py import MPI
 from petsc4py import PETSc
 from ufl import (SpatialCoordinate, TestFunction, TrialFunction, as_vector, dx,
                  exp, grad, inner, pi, sin)
+
+import dolfinx_mpc.utils
+from dolfinx_mpc import LinearProblem, MultiPointConstraint
 
 # Get PETSc int and scalar types
 complex_mode = True if np.dtype(PETSc.ScalarType).kind == 'c' else False
@@ -114,8 +117,11 @@ with Timer("~PERIODIC: Assemble and solve MPC problem"):
     print("Constrained solver iterations {0:d}".format(it))
 
 # Write solution to file
+outdir = Path("results")
+outdir.mkdir(exist_ok=True, parents=True)
+
 uh.name = "u_mpc"
-outfile = XDMFFile(MPI.COMM_WORLD, "results/demo_periodic_geometrical.xdmf", "w")
+outfile = XDMFFile(MPI.COMM_WORLD, outdir / "demo_periodic_geometrical.xdmf", "w")
 outfile.write_mesh(mesh)
 outfile.write_function(uh)
 

--- a/python/demos/demo_periodic_gep.py
+++ b/python/demos/demo_periodic_gep.py
@@ -27,17 +27,19 @@
 # eigenvalue problem is solved using SLEPc and the computed eigenvalues are
 # compared to the exact ones.
 
+from pathlib import Path
 from typing import List, Tuple
 
 import dolfinx.fem as fem
 import numpy as np
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import create_unit_square, locate_entities_boundary, meshtags
-from dolfinx_mpc import MultiPointConstraint, assemble_matrix
 from mpi4py import MPI
 from petsc4py import PETSc
 from slepc4py import SLEPc
 from ufl import TestFunction, TrialFunction, dx, grad, inner
+
+from dolfinx_mpc import MultiPointConstraint, assemble_matrix
 
 
 def print0(string: str):
@@ -336,7 +338,9 @@ def assemble_and_solve(boundary_condition: List[str] = ["dirichlet", "periodic"]
 
     # Save all eigenvectors
     suffix = "".join([bc_type[0] for bc_type in boundary_condition])
-    with XDMFFile(mesh.comm, f"results/eigenvector_{suffix}.xdmf", "w") as xdmf:
+    outdir = Path("results")
+    outdir.mkdir(exist_ok=True, parents=True)
+    with XDMFFile(mesh.comm, outdir / f"eigenvector_{suffix}.xdmf", "w") as xdmf:
         xdmf.write_mesh(mesh)
         for i, e_vec in enumerate(eigvec_r):
             xdmf.write_function(e_vec, i)

--- a/python/demos/demo_stokes.py
+++ b/python/demos/demo_stokes.py
@@ -8,15 +8,14 @@
 # interface not aligned with the coordiante axis.
 # The demos solves the Stokes problem
 
+from pathlib import Path
 
-import dolfinx_mpc.utils
 import gmsh
 import numpy as np
 import scipy.sparse.linalg
 from dolfinx import fem, io
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.io import gmshio
-from dolfinx_mpc import LinearProblem, MultiPointConstraint
 from mpi4py import MPI
 from numpy.typing import NDArray
 from petsc4py import PETSc
@@ -24,6 +23,9 @@ from ufl import (FacetNormal, FiniteElement, Identity, Measure, TestFunctions,
                  TrialFunctions, VectorElement, div, dot, dx, grad, inner,
                  outer, sym)
 from ufl.core.expr import Expr
+
+import dolfinx_mpc.utils
+from dolfinx_mpc import LinearProblem, MultiPointConstraint
 
 
 def create_mesh_gmsh(L: int = 2, H: int = 1, res: float = 0.1, theta: float = np.pi / 5,
@@ -188,9 +190,12 @@ p = U.sub(1).collapse()
 u.name = "u"
 p.name = "p"
 
-with io.VTXWriter(mesh.comm, "results/demo_stokes_u.bp", u) as vtx:
+outdir = Path("results")
+outdir.mkdir(exist_ok=True, parents=True)
+
+with io.VTXWriter(mesh.comm, outdir / "demo_stokes_u.bp", u) as vtx:
     vtx.write(0.0)
-with io.VTXWriter(mesh.comm, "results/demo_stokes_p.bp", p) as vtx:
+with io.VTXWriter(mesh.comm, outdir / "demo_stokes_p.bp", p) as vtx:
     vtx.write(0.0)
 
 # -------------------- Verification --------------------------------

--- a/python/demos/demo_stokes_nest.py
+++ b/python/demos/demo_stokes_nest.py
@@ -10,10 +10,10 @@
 # avoid using mixed function spaces. The demo also illustrates how to use
 #  block preconditioners with PETSc
 
+from pathlib import Path
 
 import basix
 import dolfinx.io
-import dolfinx_mpc.utils
 import gmsh
 import numpy as np
 import scipy.sparse.linalg
@@ -24,6 +24,7 @@ from petsc4py import PETSc
 from ufl.core.expr import Expr
 
 import dolfinx_mpc
+import dolfinx_mpc.utils
 
 
 def create_mesh_gmsh(L: int = 2, H: int = 1, res: float = 0.1, theta: float = np.pi / 5,
@@ -263,14 +264,17 @@ mpc_q.backsubstitution(ph)
 
 uh.name = "u"
 ph.name = "p"
+outdir = Path("results")
+outdir.mkdir(exist_ok=True, parents=True)
+
 with dolfinx.io.XDMFFile(
-        mesh.comm, "results/demo_stokes_nest.xdmf", "w") as outfile:
+        mesh.comm, outdir / "demo_stokes_nest.xdmf", "w") as outfile:
     outfile.write_mesh(mesh)
     outfile.write_meshtags(mt, mesh.geometry)
     outfile.write_function(uh)
     outfile.write_function(ph)
 
-with dolfinx.io.VTXWriter(mesh.comm, "results/stokes_nest_uh.bp", uh) as vtx:
+with dolfinx.io.VTXWriter(mesh.comm, outdir / "stokes_nest_uh.bp", uh) as vtx:
     vtx.write(0.0)
 # -------------------- Verification --------------------------------
 # Transfer data from the MPC problem to numpy arrays for comparison

--- a/python/tests/nitsche_ufl.py
+++ b/python/tests/nitsche_ufl.py
@@ -172,8 +172,12 @@ def nitsche_ufl(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.MeshTags, int, int],
 
     # DEBUG: Write each step of Newton iterations
     # problem.i = 0
-    # xdmf = _io.XDMFFile(mesh.comm, "results/tmp_sol.xdmf", "w")
+    # from pathlib import Path
+    # outdir = Path("results")
+    # outdir.mkdir(exist_ok=True, parents=True)
+    # xdmf = _io.XDMFFile(mesh.comm, outdir / "tmp_sol.xdmf", "w")
     # xdmf.write_mesh(mesh)
+    # xdmf.close()
 
     solver = _nls.petsc.NewtonSolver(mesh.comm, problem)
     null_space = rigid_motions_nullspace(V)


### PR DESCRIPTION
- Interpolate `XDMF` output into appropriate space (matching mesh geometry)
- Use pathlib for demo folder creation
- Remove https://gitlab.com/petsc/petsc/-/issues/1339 as it has been resolved in later version of PETSc