### PR TITLE
systematically add from future import annotations

### DIFF
--- a/python/benchmarks/bench_contact_3D.py
+++ b/python/benchmarks/bench_contact_3D.py
@@ -6,6 +6,7 @@
 #
 # Multi point constraint problem for linear elasticity with slip conditions
 # between two cubes.
+from __future__ import annotations
 
 import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser

--- a/python/benchmarks/bench_elasticity.py
+++ b/python/benchmarks/bench_elasticity.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import resource
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser

--- a/python/benchmarks/bench_elasticity_edge.py
+++ b/python/benchmarks/bench_elasticity_edge.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import resource
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser

--- a/python/benchmarks/bench_periodic.py
+++ b/python/benchmarks/bench_periodic.py
@@ -10,7 +10,7 @@
 # This file is part of DOLFINX_MPC.
 #
 # SPDX-License-Identifier:    MIT
-
+from __future__ import annotations
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path

--- a/python/benchmarks/post_proc.py
+++ b/python/benchmarks/post_proc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/python/benchmarks/ref_elasticity.py
+++ b/python/benchmarks/ref_elasticity.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import resource
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser

--- a/python/benchmarks/ref_periodic.py
+++ b/python/benchmarks/ref_periodic.py
@@ -1,4 +1,3 @@
-
 # This demo program solves Poisson's equation
 #
 #     - div grad u(x, y) = f(x, y)
@@ -15,7 +14,7 @@
 # This file is part of DOLFINX_MPC.
 #
 # SPDX-License-Identifier:    MIT
-
+from __future__ import annotations
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path

--- a/python/benchmarks/visualize_iterations.py
+++ b/python/benchmarks/visualize_iterations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator, LogLocator, NullFormatter
 import matplotlib.transforms as mtransforms

--- a/python/demos/create_and_export_mesh.py
+++ b/python/demos/create_and_export_mesh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Dict, List, Sequence, Tuple, Union
 

--- a/python/demos/demo_contact_2D.py
+++ b/python/demos/demo_contact_2D.py
@@ -11,7 +11,7 @@
 # A slip condition is implemented at the interface of the cube.
 # Additional constraints to avoid tangential movement is
 # added to the to left corner of the top cube.
-
+from __future__ import annotations
 
 import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser

--- a/python/demos/demo_contact_3D.py
+++ b/python/demos/demo_contact_3D.py
@@ -6,7 +6,7 @@
 #
 # Multi point constraint problem for linear elasticity with slip conditions
 # between two cubes.
-
+from __future__ import annotations
 
 import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser

--- a/python/demos/demo_elasticity.py
+++ b/python/demos/demo_elasticity.py
@@ -3,6 +3,8 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
+
 from pathlib import Path
 
 import dolfinx.fem as fem

--- a/python/demos/demo_elasticity_disconnect.py
+++ b/python/demos/demo_elasticity_disconnect.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier:    MIT
 #
 # Create constraint between two bodies that are not in contact
-
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/python/demos/demo_elasticity_disconnect_2D.py
+++ b/python/demos/demo_elasticity_disconnect_2D.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier:    MIT
 #
 # Create constraint between two bodies that are not in contact
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/python/demos/demo_periodic3d_topological.py
+++ b/python/demos/demo_periodic3d_topological.py
@@ -1,4 +1,3 @@
-
 # This demo program solves Poisson's equation
 #
 #     - div grad u(x, y) = f(x, y)
@@ -15,6 +14,7 @@
 # This file is part of DOLFINX_MPCX.
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict, Union

--- a/python/demos/demo_periodic_geometrical.py
+++ b/python/demos/demo_periodic_geometrical.py
@@ -10,10 +10,11 @@
 # This file is part of DOLFINX_MPCX.
 #
 # SPDX-License-Identifier:    MIT
-
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Union
+
 import dolfinx.fem as fem
 import numpy as np
 import scipy.sparse.linalg

--- a/python/demos/demo_periodic_gep.py
+++ b/python/demos/demo_periodic_gep.py
@@ -26,6 +26,7 @@
 # where A and B are real symmetric positive definite matrices. The generalized
 # eigenvalue problem is solved using SLEPc and the computed eigenvalues are
 # compared to the exact ones.
+from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Tuple

--- a/python/demos/demo_stokes.py
+++ b/python/demos/demo_stokes.py
@@ -9,6 +9,8 @@
 # We start by the various modules required for this demo
 
 # +
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Union
 

--- a/python/demos/demo_stokes_nest.py
+++ b/python/demos/demo_stokes_nest.py
@@ -9,6 +9,7 @@
 # The demos solves the Stokes problem using the nest functionality to
 # avoid using mixed function spaces. The demo also illustrates how to use
 #  block preconditioners with PETSc
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/python/dolfinx_mpc/__init__.py
+++ b/python/dolfinx_mpc/__init__.py
@@ -6,6 +6,7 @@
 """Main module for DOLFINX_MPC"""
 
 # flake8: noqa
+from __future__ import annotations
 
 import dolfinx_mpc.cpp
 

--- a/python/dolfinx_mpc/assemble_matrix.py
+++ b/python/dolfinx_mpc/assemble_matrix.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 from typing import Optional, Sequence, Union
 

--- a/python/dolfinx_mpc/assemble_vector.py
+++ b/python/dolfinx_mpc/assemble_vector.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import contextlib
 from typing import List, Optional, Sequence

--- a/python/dolfinx_mpc/dictcondition.py
+++ b/python/dolfinx_mpc/dictcondition.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import typing
 

--- a/python/dolfinx_mpc/multipointconstraint.py
+++ b/python/dolfinx_mpc/multipointconstraint.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 from typing import Callable, Dict, List, Optional, Tuple, Union
 

--- a/python/dolfinx_mpc/numba/__init__.py
+++ b/python/dolfinx_mpc/numba/__init__.py
@@ -6,7 +6,7 @@
 """Numba extension for dolfinx_mpc"""
 
 # flake8: noqa
-
+from __future__ import annotations
 
 try:
     import numba

--- a/python/dolfinx_mpc/numba/assemble_matrix.py
+++ b/python/dolfinx_mpc/numba/assemble_matrix.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 from typing import List, Optional, Tuple
 

--- a/python/dolfinx_mpc/numba/assemble_vector.py
+++ b/python/dolfinx_mpc/numba/assemble_vector.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 from typing import Optional, Tuple
 

--- a/python/dolfinx_mpc/numba/helpers.py
+++ b/python/dolfinx_mpc/numba/helpers.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import numba
 import numpy

--- a/python/dolfinx_mpc/numba/numba_setup.py
+++ b/python/dolfinx_mpc/numba/numba_setup.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import ctypes
 import ctypes.util

--- a/python/dolfinx_mpc/problem.py
+++ b/python/dolfinx_mpc/problem.py
@@ -4,6 +4,7 @@
 # This file is part of DOLFINx MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import typing
 

--- a/python/dolfinx_mpc/utils/__init__.py
+++ b/python/dolfinx_mpc/utils/__init__.py
@@ -6,6 +6,7 @@
 """Helper functions for tests in Dolfinx mpc"""
 
 # flake8: noqa
+from __future__ import annotations
 
 from .test import (compare_CSR, compare_mpc_lhs, compare_mpc_rhs,
                    gather_constants, gather_PETScMatrix, gather_PETScVector,

--- a/python/dolfinx_mpc/utils/mpc_utils.py
+++ b/python/dolfinx_mpc/utils/mpc_utils.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 from contextlib import ExitStack
 

--- a/python/dolfinx_mpc/utils/test.py
+++ b/python/dolfinx_mpc/utils/test.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 __all__ = ["gather_PETScVector", "gather_PETScMatrix", "compare_mpc_lhs", "compare_mpc_rhs",
            "gather_transformation_matrix", "compare_CSR"]

--- a/python/tests/mwe123.py
+++ b/python/tests/mwe123.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dolfinx.mesh import create_unit_square, locate_entities_boundary, meshtags
 from dolfinx import default_scalar_type
 from dolfinx import fem

--- a/python/tests/nitsche_ufl.py
+++ b/python/tests/nitsche_ufl.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 Jørgen S. Dokken and Sarah Roggendorf
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 from typing import Dict, Tuple
 

--- a/python/tests/test_cube_contact.py
+++ b/python/tests/test_cube_contact.py
@@ -6,6 +6,7 @@
 #
 # Multi point constraint problem for linear elasticity with slip conditions
 # between two cubes.
+from __future__ import annotations
 
 import dolfinx.fem as fem
 import gmsh

--- a/python/tests/test_integration_domains.py
+++ b/python/tests/test_integration_domains.py
@@ -3,7 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
-
+from __future__ import annotations
 
 import numpy as np
 import pytest

--- a/python/tests/test_lifting.py
+++ b/python/tests/test_lifting.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 from dolfinx import fem
 import dolfinx_mpc

--- a/python/tests/test_linear_problem.py
+++ b/python/tests/test_linear_problem.py
@@ -3,7 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
-
+from __future__ import annotations
 
 import numpy as np
 import pytest

--- a/python/tests/test_matrix_assembly.py
+++ b/python/tests/test_matrix_assembly.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import dolfinx.fem as fem
 import dolfinx_mpc

--- a/python/tests/test_mpc_pipeline.py
+++ b/python/tests/test_mpc_pipeline.py
@@ -3,7 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
-
+from __future__ import annotations
 
 import numpy as np
 import pytest

--- a/python/tests/test_nonlinear_assembly.py
+++ b/python/tests/test_nonlinear_assembly.py
@@ -3,6 +3,8 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
+
 import basix
 import dolfinx
 import dolfinx.fem.petsc

--- a/python/tests/test_rectangular_assembly.py
+++ b/python/tests/test_rectangular_assembly.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import basix
 import dolfinx

--- a/python/tests/test_surface_integral.py
+++ b/python/tests/test_surface_integral.py
@@ -3,7 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
-
+from __future__ import annotations
 
 import dolfinx.fem as fem
 import numpy as np

--- a/python/tests/test_vector_assembly.py
+++ b/python/tests/test_vector_assembly.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import dolfinx.fem as fem
 import dolfinx_mpc

--- a/python/tests/test_vector_poisson.py
+++ b/python/tests/test_vector_poisson.py
@@ -3,6 +3,7 @@
 # This file is part of DOLFINX_MPC
 #
 # SPDX-License-Identifier:    MIT
+from __future__ import annotations
 
 import dolfinx.fem as fem
 import numpy as np


### PR DESCRIPTION
for Python 3.8 annotation compatibility, avoiding runtime errors when new-style annotations are used.