### PR TITLE
Use isort on all Python files

### DIFF
--- a/python/.isort.cfg
+++ b/python/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+src_paths = benchmarks,demos,dolfinx_mpc
+known_first_party = dolfinx_mpc
+known_third_party = basix,dolfinx,ffcx,ufl,gmsh,numba,numpy,pytest,pyvista
+known_mpi = mpi4py,petsc4py
+sections=FUTURE,STDLIB,MPI,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+sections=FUTURE,STDLIB,MPI,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/python/benchmarks/bench_contact_3D.py
+++ b/python/benchmarks/bench_contact_3D.py
@@ -12,6 +12,9 @@ import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import basix.ufl
 import numpy as np
 from basix.ufl import element
@@ -24,15 +27,13 @@ from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, compute_midpoints, create_mesh,
                           create_unit_cube, locate_entities_boundary, meshtags,
                           refine)
-from dolfinx_mpc.utils import (create_normal_approximation, log_info,
-                               rigid_motions_nullspace, rotation_matrix)
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (Identity, Mesh, TestFunction, TrialFunction, dx, grad, inner,
                  sym, tr)
 
 from dolfinx_mpc import (MultiPointConstraint, apply_lifting, assemble_matrix,
                          assemble_vector)
+from dolfinx_mpc.utils import (create_normal_approximation, log_info,
+                               rigid_motions_nullspace, rotation_matrix)
 
 comm = MPI.COMM_WORLD
 

--- a/python/benchmarks/bench_elasticity.py
+++ b/python/benchmarks/bench_elasticity.py
@@ -10,17 +10,18 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 from typing import Optional
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import basix.ufl
 import h5py
 import numpy as np
 from dolfinx.common import Timer, TimingType, list_timings
-from dolfinx.fem import (Constant, Function, functionspace, dirichletbc, form,
+from dolfinx.fem import (Constant, Function, dirichletbc, form, functionspace,
                          locate_dofs_topological, set_bc)
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (create_unit_cube, locate_entities_boundary, meshtags,
                           refine)
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (Identity, TestFunction, TrialFunction, ds, dx, grad, inner,
                  sym, tr)
 

--- a/python/benchmarks/bench_elasticity_edge.py
+++ b/python/benchmarks/bench_elasticity_edge.py
@@ -9,19 +9,20 @@ import resource
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import basix.ufl
 import h5py
 import numpy as np
 from dolfinx import default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
-from dolfinx.fem import (Constant, Function, functionspace, dirichletbc, form,
+from dolfinx.fem import (Constant, Function, dirichletbc, form, functionspace,
                          locate_dofs_topological)
 from dolfinx.fem.petsc import set_bc
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, create_unit_cube, locate_entities_boundary,
                           meshtags)
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (Identity, SpatialCoordinate, TestFunction, TrialFunction,
                  as_vector, ds, dx, grad, inner, sym, tr)
 

--- a/python/benchmarks/bench_periodic.py
+++ b/python/benchmarks/bench_periodic.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import h5py
 import numpy as np
 from dolfinx import default_scalar_type
@@ -25,8 +28,6 @@ from dolfinx.fem.petsc import set_bc
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, create_unit_cube, locate_entities_boundary,
                           meshtags)
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (SpatialCoordinate, TestFunction, TrialFunction, dx, exp, grad,
                  inner, pi, sin)
 

--- a/python/benchmarks/post_proc.py
+++ b/python/benchmarks/post_proc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 # Res 0.1 31776, 0.05 234546, 0.025 1801086, 0.02 3488856, 0.0175 5147961,0.015 7960200
 dofs = [31776, 234546, 1801086, 3488856, 5147961, 7960200]

--- a/python/benchmarks/ref_elasticity.py
+++ b/python/benchmarks/ref_elasticity.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from time import perf_counter
 from typing import Optional
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import basix.ufl
 import h5py
 import numpy as np
@@ -24,8 +27,6 @@ from dolfinx.io import XDMFFile
 from dolfinx.log import LogLevel, log, set_log_level
 from dolfinx.mesh import (CellType, create_unit_cube, locate_entities_boundary,
                           meshtags, refine)
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (Identity, SpatialCoordinate, TestFunction, TrialFunction,
                  as_vector, ds, dx, grad, inner, sym, tr)
 

--- a/python/benchmarks/ref_periodic.py
+++ b/python/benchmarks/ref_periodic.py
@@ -21,19 +21,20 @@ from pathlib import Path
 from time import perf_counter
 from typing import Optional
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import h5py
 import numpy as np
 from dolfinx import default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
-from dolfinx.fem import (Function, functionspace, dirichletbc, form,
+from dolfinx.fem import (Function, dirichletbc, form, functionspace,
                          locate_dofs_geometrical)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.io import XDMFFile
 from dolfinx.log import LogLevel, log, set_log_level
 from dolfinx.mesh import CellType, create_unit_cube, refine
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (SpatialCoordinate, TestFunction, TrialFunction, dx, exp, grad,
                  inner, pi, sin)
 

--- a/python/benchmarks/visualize_iterations.py
+++ b/python/benchmarks/visualize_iterations.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import matplotlib.pyplot as plt
-from matplotlib.ticker import MaxNLocator, LogLocator, NullFormatter
-import matplotlib.transforms as mtransforms
-import h5py
-import mpi4py
 import argparse
 import sys
+
+import mpi4py
+
+import h5py
+import matplotlib.pyplot as plt
+import matplotlib.transforms as mtransforms
 import numpy as np
+from matplotlib.ticker import LogLocator, MaxNLocator, NullFormatter
 
 
 def visualize_elasticity():

--- a/python/demos/create_and_export_mesh.py
+++ b/python/demos/create_and_export_mesh.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, List, Sequence, Tuple, Union
 
+from mpi4py import MPI
+
 import dolfinx.common as _common
 import dolfinx.cpp as _cpp
 import dolfinx.io as _io
 import dolfinx.mesh as _mesh
-import dolfinx_mpc.utils as _utils
 import gmsh
 import numpy as np
 import ufl
 from basix.ufl import element
 from dolfinx.io import gmshio
-from mpi4py import MPI
+
+import dolfinx_mpc.utils as _utils
 
 
 def gmsh_3D_stacked(celltype: str, theta: float, res: float = 0.1,

--- a/python/demos/demo_contact_2D.py
+++ b/python/demos/demo_contact_2D.py
@@ -17,10 +17,12 @@ import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import scipy.sparse.linalg
-from create_and_export_mesh import gmsh_2D_stacked, mesh_2D_dolfin
-from dolfinx import default_scalar_type, default_real_type
+from dolfinx import default_real_type, default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.fem import (Constant, dirichletbc, form, functionspace,
                          locate_dofs_geometrical)
@@ -29,11 +31,10 @@ from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
 from dolfinx.io import XDMFFile
 from dolfinx.log import LogLevel, set_log_level
 from dolfinx.mesh import locate_entities_boundary, meshtags
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (Identity, Measure, TestFunction, TrialFunction, dx, grad,
                  inner, sym, tr)
 
+from create_and_export_mesh import gmsh_2D_stacked, mesh_2D_dolfin
 from dolfinx_mpc import LinearProblem, MultiPointConstraint
 from dolfinx_mpc.utils import (compare_mpc_lhs, compare_mpc_rhs,
                                create_normal_approximation,

--- a/python/demos/demo_contact_3D.py
+++ b/python/demos/demo_contact_3D.py
@@ -12,18 +12,19 @@ import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.fem as fem
 import numpy as np
 import scipy.sparse.linalg
-from create_and_export_mesh import gmsh_3D_stacked, mesh_3D_dolfin
 from dolfinx import default_real_type, default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import CellType
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import Identity, TestFunction, TrialFunction, dx, grad, inner, sym, tr
 
+from create_and_export_mesh import gmsh_3D_stacked, mesh_3D_dolfin
 from dolfinx_mpc import (MultiPointConstraint, apply_lifting, assemble_matrix,
                          assemble_vector)
 from dolfinx_mpc.utils import (compare_mpc_lhs, compare_mpc_rhs,

--- a/python/demos/demo_elasticity.py
+++ b/python/demos/demo_elasticity.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.fem as fem
 import numpy as np
 import scipy.sparse.linalg
@@ -14,8 +17,6 @@ from dolfinx import default_scalar_type
 from dolfinx.common import Timer
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import create_unit_square, locate_entities_boundary
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (Identity, SpatialCoordinate, TestFunction, TrialFunction,
                  as_vector, dx, grad, inner, sym, tr)
 

--- a/python/demos/demo_elasticity_disconnect.py
+++ b/python/demos/demo_elasticity_disconnect.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mpi4py import MPI
+
 import basix.ufl
 import gmsh
 import numpy as np
@@ -16,7 +18,6 @@ from dolfinx import default_scalar_type
 from dolfinx.fem import (Constant, Function, dirichletbc, functionspace,
                          locate_dofs_topological)
 from dolfinx.io import XDMFFile, gmshio
-from mpi4py import MPI
 from ufl import (Identity, Measure, SpatialCoordinate, TestFunction,
                  TrialFunction, as_vector, grad, inner, sym, tr)
 

--- a/python/demos/demo_elasticity_disconnect_2D.py
+++ b/python/demos/demo_elasticity_disconnect_2D.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mpi4py import MPI
+
 import gmsh
 import numpy as np
 from dolfinx import default_scalar_type
@@ -17,7 +19,6 @@ from dolfinx.fem import (Constant, Function, FunctionSpace, dirichletbc,
                          locate_dofs_topological)
 from dolfinx.io import XDMFFile, gmshio
 from dolfinx.mesh import locate_entities_boundary
-from mpi4py import MPI
 from ufl import (Identity, Measure, SpatialCoordinate, TestFunction,
                  TrialFunction, grad, inner, sym, tr)
 

--- a/python/demos/demo_periodic3d_topological.py
+++ b/python/demos/demo_periodic3d_topological.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Union
 
+from mpi4py import MPI
+
 import dolfinx.fem as fem
 import numpy as np
 import scipy.sparse.linalg
@@ -27,7 +29,6 @@ from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.io import VTXWriter
 from dolfinx.mesh import (CellType, create_unit_cube, locate_entities_boundary,
                           meshtags)
-from mpi4py import MPI
 from numpy.typing import NDArray
 from ufl import (SpatialCoordinate, TestFunction, TrialFunction, as_vector, dx,
                  exp, grad, inner, pi, sin)

--- a/python/demos/demo_periodic_geometrical.py
+++ b/python/demos/demo_periodic_geometrical.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Union
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.fem as fem
 import numpy as np
 import scipy.sparse.linalg
@@ -22,8 +25,6 @@ from dolfinx import default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import create_unit_square, locate_entities_boundary
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl import (SpatialCoordinate, TestFunction, TrialFunction, as_vector, dx,
                  exp, grad, inner, pi, sin)
 

--- a/python/demos/demo_periodic_gep.py
+++ b/python/demos/demo_periodic_gep.py
@@ -31,13 +31,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Tuple
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.fem as fem
 import numpy as np
 from dolfinx import default_scalar_type
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import create_unit_square, locate_entities_boundary, meshtags
-from mpi4py import MPI
-from petsc4py import PETSc
 from slepc4py import SLEPc
 from ufl import TestFunction, TrialFunction, dx, grad, inner
 

--- a/python/demos/demo_stokes.py
+++ b/python/demos/demo_stokes.py
@@ -14,21 +14,23 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Union
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import basix.ufl
-import dolfinx_mpc.utils
 import gmsh
 import numpy as np
 import scipy.sparse.linalg
 from dolfinx import common, default_scalar_type, fem, io
 from dolfinx.io import gmshio
-from mpi4py import MPI
 from numpy.typing import NDArray
-from petsc4py import PETSc
 from ufl import (FacetNormal, Identity, Measure, TestFunctions, TrialFunctions,
                  div, dot, dx, grad, inner, outer, sym)
 from ufl.core.expr import Expr
 
+import dolfinx_mpc.utils
 from dolfinx_mpc import LinearProblem, MultiPointConstraint
+
 # -
 # ## Mesh generation
 #

--- a/python/demos/demo_stokes_nest.py
+++ b/python/demos/demo_stokes_nest.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import basix
 import dolfinx.io
 import gmsh
@@ -21,8 +24,6 @@ import scipy.sparse.linalg
 import ufl
 from dolfinx import default_scalar_type
 from dolfinx.io import gmshio
-from mpi4py import MPI
-from petsc4py import PETSc
 from ufl.core.expr import Expr
 
 import dolfinx_mpc

--- a/python/dolfinx_mpc/__init__.py
+++ b/python/dolfinx_mpc/__init__.py
@@ -11,13 +11,12 @@ from __future__ import annotations
 import dolfinx_mpc.cpp
 
 # New local assemblies
-from .assemble_matrix import assemble_matrix, create_matrix_nest, \
-    assemble_matrix_nest, create_sparsity_pattern
-from .assemble_vector import assemble_vector, apply_lifting, \
-    assemble_vector_nest, create_vector_nest
+from .assemble_matrix import (assemble_matrix, assemble_matrix_nest,
+                              create_matrix_nest, create_sparsity_pattern)
+from .assemble_vector import (apply_lifting, assemble_vector,
+                              assemble_vector_nest, create_vector_nest)
 from .multipointconstraint import MultiPointConstraint
 from .problem import LinearProblem
-
 
 __all__ = ["assemble_matrix", "create_matrix_nest", "assemble_matrix_nest",
            "assemble_vector", "apply_lifting", "assemble_vector_nest", 

--- a/python/dolfinx_mpc/assemble_matrix.py
+++ b/python/dolfinx_mpc/assemble_matrix.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 from typing import Optional, Sequence, Union
 
+from petsc4py import PETSc as _PETSc
+
 import dolfinx.cpp as _cpp
 import dolfinx.fem as _fem
-from petsc4py import PETSc as _PETSc
 
 from dolfinx_mpc import cpp
 

--- a/python/dolfinx_mpc/assemble_vector.py
+++ b/python/dolfinx_mpc/assemble_vector.py
@@ -8,15 +8,18 @@ from __future__ import annotations
 import contextlib
 from typing import List, Optional, Sequence
 
+from petsc4py import PETSc as _PETSc
+
 import dolfinx.cpp as _cpp
 import dolfinx.fem as _fem
 import dolfinx.la as _la
-import ufl
-from dolfinx.common import Timer
-from petsc4py import PETSc as _PETSc
 import numpy
-import dolfinx_mpc.cpp
+import ufl
 from dolfinx import default_scalar_type
+from dolfinx.common import Timer
+
+import dolfinx_mpc.cpp
+
 from .multipointconstraint import MultiPointConstraint, _float_classes
 
 

--- a/python/dolfinx_mpc/multipointconstraint.py
+++ b/python/dolfinx_mpc/multipointconstraint.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
+from petsc4py import PETSc as _PETSc
+
 import dolfinx.cpp as _cpp
 import dolfinx.fem as _fem
 import dolfinx.mesh as _mesh
 import numpy
 import numpy.typing as npt
 from dolfinx import default_scalar_type
-from petsc4py import PETSc as _PETSc
 
 import dolfinx_mpc.cpp
 

--- a/python/dolfinx_mpc/numba/assemble_matrix.py
+++ b/python/dolfinx_mpc/numba/assemble_matrix.py
@@ -7,17 +7,19 @@ from __future__ import annotations
 
 from typing import List, Optional, Tuple
 
+from petsc4py import PETSc as _PETSc
+
 import cffi
+import dolfinx
 import dolfinx.cpp as _cpp
 import dolfinx.fem as _fem
 import numba
 import numpy
 import numpy.typing as npt
-import dolfinx
 from dolfinx.common import Timer
+
 from dolfinx_mpc.assemble_matrix import create_sparsity_pattern
 from dolfinx_mpc.multipointconstraint import MultiPointConstraint
-from petsc4py import PETSc as _PETSc
 
 from .helpers import _bcs, _forms, extract_slave_cells, pack_slave_facet_info
 from .numba_setup import initialize_petsc, sink

--- a/python/dolfinx_mpc/numba/assemble_vector.py
+++ b/python/dolfinx_mpc/numba/assemble_vector.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 
+from petsc4py import PETSc as _PETSc
+
 import cffi
 import dolfinx
 import dolfinx.cpp as _cpp
@@ -17,7 +19,6 @@ import numba
 import numpy
 import numpy.typing as npt
 from dolfinx.common import Timer
-from petsc4py import PETSc as _PETSc
 
 from dolfinx_mpc.multipointconstraint import MultiPointConstraint
 

--- a/python/dolfinx_mpc/numba/helpers.py
+++ b/python/dolfinx_mpc/numba/helpers.py
@@ -5,11 +5,12 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from typing import Union
+
+import dolfinx.cpp as _cpp
 import numba
 import numpy
 import numpy.typing as npt
-from typing import Union
-import dolfinx.cpp as _cpp
 
 _forms = Union[_cpp.fem.Form_float32, _cpp.fem.Form_float64, _cpp.fem.Form_complex128]
 _bcs = Union[_cpp.fem.DirichletBC_float32, _cpp.fem.DirichletBC_float64,

--- a/python/dolfinx_mpc/numba/numba_setup.py
+++ b/python/dolfinx_mpc/numba/numba_setup.py
@@ -9,16 +9,17 @@ import ctypes
 import ctypes.util
 import importlib
 import os
+import typing
 
+import petsc4py.lib
+from mpi4py import MPI
+from petsc4py import PETSc
+from petsc4py import get_config as PETSc_get_config
+
+import cffi
 import numba
 import numba.core.typing.cffi_utils as cffi_support
 import numpy as np
-import typing
-import cffi
-import petsc4py.lib
-from mpi4py import MPI
-from petsc4py import get_config as PETSc_get_config
-from petsc4py import PETSc
 
 
 def initialize_petsc() -> typing.Tuple[cffi.FFI, typing.Any]:

--- a/python/dolfinx_mpc/problem.py
+++ b/python/dolfinx_mpc/problem.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 
 import typing
 
+from petsc4py import PETSc
+
 import dolfinx.fem.petsc
 import ufl
 from dolfinx import cpp as _cpp
 from dolfinx import fem as _fem
 from dolfinx import la as _la
-from petsc4py import PETSc
 
 from .assemble_matrix import assemble_matrix, create_sparsity_pattern
 from .assemble_vector import apply_lifting, assemble_vector

--- a/python/dolfinx_mpc/utils/__init__.py
+++ b/python/dolfinx_mpc/utils/__init__.py
@@ -8,13 +8,13 @@
 # flake8: noqa
 from __future__ import annotations
 
+from .mpc_utils import (create_normal_approximation,
+                        create_point_to_point_constraint,
+                        determine_closest_block, facet_normal_approximation,
+                        log_info, rigid_motions_nullspace, rotation_matrix)
 from .test import (compare_CSR, compare_mpc_lhs, compare_mpc_rhs,
                    gather_constants, gather_PETScMatrix, gather_PETScVector,
                    gather_transformation_matrix, get_assemblers)
-from .mpc_utils import (create_normal_approximation,
-                        create_point_to_point_constraint, determine_closest_block,
-                        facet_normal_approximation, log_info,
-                        rigid_motions_nullspace, rotation_matrix)
 
 __all__ = ["get_assemblers", "gather_PETScVector", "gather_PETScMatrix", "compare_mpc_lhs",
            "compare_mpc_rhs", "gather_transformation_matrix", "compare_CSR", "gather_constants",

--- a/python/dolfinx_mpc/utils/mpc_utils.py
+++ b/python/dolfinx_mpc/utils/mpc_utils.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 from contextlib import ExitStack
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.common as _common
 import dolfinx.cpp as _cpp
 import dolfinx.fem as _fem
@@ -17,8 +20,6 @@ import dolfinx.mesh as _mesh
 import numpy as np
 import ufl
 from dolfinx import default_scalar_type as _dt
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc.cpp
 

--- a/python/dolfinx_mpc/utils/test.py
+++ b/python/dolfinx_mpc/utils/test.py
@@ -8,14 +8,17 @@ from __future__ import annotations
 __all__ = ["gather_PETScVector", "gather_PETScMatrix", "compare_mpc_lhs", "compare_mpc_rhs",
            "gather_transformation_matrix", "compare_CSR"]
 
-import pytest
-import numpy as np
+from typing import Any
+
 from mpi4py import MPI
 from petsc4py import PETSc
-import scipy.sparse
-import dolfinx_mpc
+
 import dolfinx.common
-from typing import Any
+import numpy as np
+import pytest
+import scipy.sparse
+
+import dolfinx_mpc
 
 
 @pytest.fixture

--- a/python/tests/mwe123.py
+++ b/python/tests/mwe123.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
-from dolfinx.mesh import create_unit_square, locate_entities_boundary, meshtags
-from dolfinx import default_scalar_type
-from dolfinx import fem
-import dolfinx_mpc
+
 from mpi4py import MPI
+
 import numpy as np
+from dolfinx import default_scalar_type, fem
+from dolfinx.mesh import create_unit_square, locate_entities_boundary, meshtags
+
+import dolfinx_mpc
+
 mesh = create_unit_square(MPI.COMM_WORLD, 1, 1)
 V = fem.functionspace(mesh, ("Lagrange", 1))
 

--- a/python/tests/nitsche_ufl.py
+++ b/python/tests/nitsche_ufl.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Dict, Tuple
 
+from petsc4py import PETSc as _PETSc
+
 import numpy as np
 import ufl
 from dolfinx import common as _common
@@ -14,7 +16,6 @@ from dolfinx import mesh as dmesh
 from dolfinx import nls as _nls
 from dolfinx_contact.helpers import (R_minus, epsilon, lame_parameters,
                                      rigid_motions_nullspace, sigma_func)
-from petsc4py import PETSc as _PETSc
 
 __all__ = ["nitsche_ufl"]
 

--- a/python/tests/test_cube_contact.py
+++ b/python/tests/test_cube_contact.py
@@ -8,6 +8,9 @@
 # between two cubes.
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.fem as fem
 import gmsh
 import numpy as np
@@ -17,8 +20,6 @@ import ufl
 from dolfinx import default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.io import gmshio
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc
 import dolfinx_mpc.utils

--- a/python/tests/test_integration_domains.py
+++ b/python/tests/test_integration_domains.py
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 import scipy.sparse.linalg
@@ -12,8 +15,6 @@ import ufl
 from dolfinx import default_scalar_type, fem
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.mesh import compute_midpoints, create_unit_square, meshtags
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc
 from dolfinx_mpc.utils import get_assemblers  # noqa: F401

--- a/python/tests/test_lifting.py
+++ b/python/tests/test_lifting.py
@@ -5,18 +5,20 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
-from dolfinx import fem
-import dolfinx_mpc
-import dolfinx_mpc.utils
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 import scipy.sparse.linalg
 import ufl
+from dolfinx import fem
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.mesh import CellType, create_unit_square
+
+import dolfinx_mpc
+import dolfinx_mpc.utils
 from dolfinx_mpc.utils import get_assemblers  # noqa: F401
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 @pytest.mark.skipif(MPI.COMM_WORLD.size > 1,

--- a/python/tests/test_linear_problem.py
+++ b/python/tests/test_linear_problem.py
@@ -5,14 +5,15 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 import scipy.sparse.linalg
 import ufl
 from dolfinx import default_scalar_type, fem
 from dolfinx.mesh import create_unit_square, locate_entities_boundary, meshtags
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc
 import dolfinx_mpc.utils

--- a/python/tests/test_matrix_assembly.py
+++ b/python/tests/test_matrix_assembly.py
@@ -5,16 +5,18 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+
 import dolfinx.fem as fem
-import dolfinx_mpc
-import dolfinx_mpc.utils
 import numpy as np
 import pytest
 import ufl
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.mesh import CellType, create_unit_square
+
+import dolfinx_mpc
+import dolfinx_mpc.utils
 from dolfinx_mpc.utils import get_assemblers  # noqa: F401
-from mpi4py import MPI
 
 root = 0
 

--- a/python/tests/test_mpc_pipeline.py
+++ b/python/tests/test_mpc_pipeline.py
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 import scipy.sparse.linalg
@@ -12,8 +15,6 @@ import ufl
 from dolfinx import default_scalar_type, fem
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.mesh import create_unit_square
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc
 import dolfinx_mpc.utils

--- a/python/tests/test_nonlinear_assembly.py
+++ b/python/tests/test_nonlinear_assembly.py
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import basix
 import dolfinx
 import dolfinx.fem.petsc
@@ -13,8 +16,6 @@ import dolfinx.nls.petsc
 import numpy as np
 import pytest
 import ufl
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc
 

--- a/python/tests/test_rectangular_assembly.py
+++ b/python/tests/test_rectangular_assembly.py
@@ -5,18 +5,19 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import basix
 import dolfinx
 import dolfinx.fem
 import dolfinx.mesh
-import dolfinx_mpc.utils
 import numpy as np
 import pytest
 import ufl
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc
+import dolfinx_mpc.utils
 
 
 @pytest.mark.parametrize("cell_type",

--- a/python/tests/test_surface_integral.py
+++ b/python/tests/test_surface_integral.py
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.fem as fem
 import numpy as np
 import pytest
@@ -13,8 +16,6 @@ import ufl
 from dolfinx import default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.mesh import create_unit_square, locate_entities_boundary, meshtags
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc
 import dolfinx_mpc.utils

--- a/python/tests/test_vector_assembly.py
+++ b/python/tests/test_vector_assembly.py
@@ -5,17 +5,19 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.fem as fem
-import dolfinx_mpc
-import dolfinx_mpc.utils
 import numpy as np
 import pytest
 import ufl
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.mesh import CellType, create_unit_square
+
+import dolfinx_mpc
+import dolfinx_mpc.utils
 from dolfinx_mpc.utils import get_assemblers  # noqa: F401
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 @pytest.mark.parametrize("get_assemblers", ["C++", "numba"], indirect=True)

--- a/python/tests/test_vector_poisson.py
+++ b/python/tests/test_vector_poisson.py
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier:    MIT
 from __future__ import annotations
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import dolfinx.fem as fem
 import numpy as np
 import pytest
@@ -13,8 +16,6 @@ import ufl
 from dolfinx import default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.mesh import create_unit_square
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import dolfinx_mpc
 import dolfinx_mpc.utils


### PR DESCRIPTION
To avoid issue with MPI initialization, ref:
https://github.com/FEniCS/dolfinx/pull/2826