### PR TITLE
standard array include

### DIFF
--- a/python/dolfinx_mpc/mpc.cpp
+++ b/python/dolfinx_mpc/mpc.cpp
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier:    MIT
 
-#include <array.h>
+#include <array>
 #include <caster_petsc.h>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/fem/DirichletBC.h>


### PR DESCRIPTION
I don't understand what's happening sometimes but not all the time, but `#include <array.h>` is resulting in a header not being found on some of my test builds, while the standard `#include <array>` works.