### PR TITLE
use numpy.testing for array asserts

### DIFF
--- a/python/tests/test_cube_contact.py
+++ b/python/tests/test_cube_contact.py
@@ -14,6 +14,7 @@ from petsc4py import PETSc
 import dolfinx.fem as fem
 import gmsh
 import numpy as np
+import numpy.testing as nt
 import pytest
 import scipy.sparse.linalg
 import ufl
@@ -301,7 +302,7 @@ def test_cube_contact(generate_hex_boxes, nonslip, get_assemblers):  # noqa: F81
             # Back substitution to full solution vector
             uh_numpy = K @ d
             atol = 1000 * np.finfo(default_scalar_type).resolution
-            assert np.allclose(uh_numpy, u_mpc, atol=atol)
+            nt.assert_allclose(uh_numpy, u_mpc, atol=atol)
     L_org.destroy()
 
     list_timings(comm, [TimingType.wall])

--- a/python/tests/test_integration_domains.py
+++ b/python/tests/test_integration_domains.py
@@ -9,6 +9,7 @@ from mpi4py import MPI
 from petsc4py import PETSc
 
 import numpy as np
+import numpy.testing as nt
 import pytest
 import scipy.sparse.linalg
 import ufl
@@ -117,7 +118,7 @@ def test_cell_domains(get_assemblers):  # noqa: F811
             d = scipy.sparse.linalg.spsolve(KTAK.astype(scipy_dtype), reduced_L.astype(scipy_dtype))
             # Back substitution to full solution vector
             uh_numpy = K.astype(scipy_dtype) @ d.astype(scipy_dtype)
-            assert np.allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
+            nt.assert_allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
                                * np.finfo(default_scalar_type).resolution)
     solver.destroy()
     b.destroy()

--- a/python/tests/test_lifting.py
+++ b/python/tests/test_lifting.py
@@ -114,8 +114,8 @@ def test_lifting(get_assemblers):  # noqa: F811
             reduced_L = K.T @ (L_np)  # - constants)
             # Solve linear system
             d = scipy.sparse.linalg.spsolve(KTAK, reduced_L)
-            # Back substitution to full solution vecto
+            # Back substitution to full solution vector
             uh_numpy = K @ (d)  # + constants)
-            nt.assert_allclose(uh_numpy, u_mpc)
+            nt.assert_allclose(uh_numpy, u_mpc, rtol=1e-5, atol=1e-8)
 
     list_timings(comm, [TimingType.wall])

--- a/python/tests/test_lifting.py
+++ b/python/tests/test_lifting.py
@@ -9,6 +9,7 @@ from mpi4py import MPI
 from petsc4py import PETSc
 
 import numpy as np
+import numpy.testing as nt
 import pytest
 import scipy.sparse.linalg
 import ufl
@@ -115,6 +116,6 @@ def test_lifting(get_assemblers):  # noqa: F811
             d = scipy.sparse.linalg.spsolve(KTAK, reduced_L)
             # Back substitution to full solution vecto
             uh_numpy = K @ (d)  # + constants)
-            assert np.allclose(uh_numpy, u_mpc)
+            nt.assert_allclose(uh_numpy, u_mpc)
 
     list_timings(comm, [TimingType.wall])

--- a/python/tests/test_linear_problem.py
+++ b/python/tests/test_linear_problem.py
@@ -9,6 +9,7 @@ from mpi4py import MPI
 from petsc4py import PETSc
 
 import numpy as np
+import numpy.testing as nt
 import pytest
 import scipy.sparse.linalg
 import ufl
@@ -85,7 +86,7 @@ def test_pipeline(u_from_mpc):
             d = scipy.sparse.linalg.spsolve(KTAK, reduced_L)
             # Back substitution to full solution vector
             uh_numpy = K.astype(scipy_dtype) @ d
-            assert np.allclose(uh_numpy.astype(u_mpc.dtype), u_mpc,
+            nt.assert_allclose(uh_numpy.astype(u_mpc.dtype), u_mpc,
                                rtol=500
                                * np.finfo(default_scalar_type).resolution,
                                atol=500

--- a/python/tests/test_mpc_pipeline.py
+++ b/python/tests/test_mpc_pipeline.py
@@ -9,6 +9,7 @@ from mpi4py import MPI
 from petsc4py import PETSc
 
 import numpy as np
+import numpy.testing as nt
 import pytest
 import scipy.sparse.linalg
 import ufl
@@ -101,7 +102,7 @@ def test_pipeline(master_point, get_assemblers):  # noqa: F811
             d = scipy.sparse.linalg.spsolve(KTAK, reduced_L)
             # Back substitution to full solution vector
             uh_numpy = K.astype(scipy_dtype) @ d
-            assert np.allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
+            nt.assert_allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
                                * np.finfo(default_scalar_type).resolution)
 
     list_timings(comm, [TimingType.wall])
@@ -169,7 +170,7 @@ def test_linearproblem(master_point):
             d = scipy.sparse.linalg.spsolve(KTAK, reduced_L)
             # Back substitution to full solution vector
             uh_numpy = K.astype(scipy_dtype) @ d
-            assert np.allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
+            nt.assert_allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
                                * np.finfo(default_scalar_type).resolution)
 
     list_timings(comm, [TimingType.wall])

--- a/python/tests/test_surface_integral.py
+++ b/python/tests/test_surface_integral.py
@@ -10,6 +10,7 @@ from petsc4py import PETSc
 
 import dolfinx.fem as fem
 import numpy as np
+import numpy.testing as nt
 import pytest
 import scipy.sparse.linalg
 import ufl
@@ -132,7 +133,7 @@ def test_surface_integrals(get_assemblers):  # noqa: F811
             d = scipy.sparse.linalg.spsolve(KTAK, reduced_L)
             # Back substitution to full solution vector
             uh_numpy = K.astype(scipy_dtype) @ d
-            assert np.allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
+            nt.assert_allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
                                * np.finfo(default_scalar_type).resolution)
 
     L_org.destroy()

--- a/python/tests/test_vector_poisson.py
+++ b/python/tests/test_vector_poisson.py
@@ -10,6 +10,7 @@ from petsc4py import PETSc
 
 import dolfinx.fem as fem
 import numpy as np
+import numpy.testing as nt
 import pytest
 import scipy.sparse.linalg
 import ufl
@@ -121,7 +122,7 @@ def test_vector_possion(Nx, Ny, slave_space, master_space, get_assemblers):  # n
             d = scipy.sparse.linalg.spsolve(KTAK, reduced_L)
             # Back substitution to full solution vector
             uh_numpy = K.astype(scipy_dtype) @ d
-            assert np.allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
+            nt.assert_allclose(uh_numpy.astype(u_mpc.dtype), u_mpc, rtol=500
                                * np.finfo(default_scalar_type).resolution)
 
     b.destroy()


### PR DESCRIPTION
yields better error messages when tests fail

especially for `nt.assert_allclose`, where you get e.g.:

```
E           Not equal to tolerance rtol=5e-13, atol=5e-13
E
E           Mismatched elements: 36 / 36 (100%)
E           Max absolute difference: 0.01901673
E           Max relative difference: inf
E            x: array([-0.000405, -0.00106 , -0.014619, -0.001312, -0.007975, -0.01086 ,
E                   0.012003,  0.00969 , -0.0054  ,  0.018766,  0.013964,  0.007522,
E                   0.000405, -0.000405, -0.00106 ,  0.010049, -0.001312, -0.010049,...
E            y: array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
E                  0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
E                  0., 0.])
```

rather than the same assertion with `assert np.allclose`:

```
E               AssertionError: assert False
E                +  where False = <function allclose at 0x10ac612f0>(array([-0.00040501, -0.00106036, -0.01461884, -0.00131173, -0.00797458,\n       -0.0108598 ,  0.0120033 ,  0.00969028, -0.0054    ,  0.01876642,\n        0.0139635 ,  0.00752241,  0.00040501, -0.00040501, -0.00106036,\n        0.0100491 , -0.00131173, -0.0100491 ,  0.00131173,  0.00106036,\n       -0.0139635 , -0.00752241,  0.00040501, -0.00969028, -0.01876642,\n        0.0054    ,  0.00797458, -0.0120033 , -0.01901673,  0.0108598 ,\n        0.01461884,  0.01134797, -0.01134797,  0.00131173,  0.00106036,\n        0.01901673]), array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n       0., 0.]), rtol=(500 * 1e-15), atol=(500 * 1e-15))
E                +    where <function allclose at 0x10ac612f0> = np.allclose
E                +    and   array([-0.00040501, -0.00106036, -0.01461884, -0.00131173, -0.00797458,\n       -0.0108598 ,  0.0120033 ,  0.00969028, -0.0054    ,  0.01876642,\n        0.0139635 ,  0.00752241,  0.00040501, -0.00040501, -0.00106036,\n        0.0100491 , -0.00131173, -0.0100491 ,  0.00131173,  0.00106036,\n       -0.0139635 , -0.00752241,  0.00040501, -0.00969028, -0.01876642,\n        0.0054    ,  0.00797458, -0.0120033 , -0.01901673,  0.0108598 ,\n        0.01461884,  0.01134797, -0.01134797,  0.00131173,  0.00106036,\n        0.01901673]) = <built-in method astype of numpy.ndarray object at 0x12d9c15f0>(dtype('float64'))
E                +      where <built-in method astype of numpy.ndarray object at 0x12d9c15f0> = array([-0.00040501, -0.00106036, -0.01461884, -0.00131173, -0.00797458,\n       -0.0108598 ,  0.0120033 ,  0.00969028, -0.0054    ,  0.01876642,\n        0.0139635 ,  0.00752241,  0.00040501, -0.00040501, -0.00106036,\n        0.0100491 , -0.00131173, -0.0100491 ,  0.00131173,  0.00106036,\n       -0.0139635 , -0.00752241,  0.00040501, -0.00969028, -0.01876642,\n        0.0054    ,  0.00797458, -0.0120033 , -0.01901673,  0.0108598 ,\n        0.01461884,  0.01134797, -0.01134797,  0.00131173,  0.00106036,\n        0.01901673]).astype
E                +      and   dtype('float64') = array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n       0., 0.]).dtype
E                +    and   1e-15 = finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64).resolution
E                +      where finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64) = <class 'numpy.finfo'>(default_scalar_type)
E                +        where <class 'numpy.finfo'> = np.finfo
E                +    and   1e-15 = finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64).resolution
E                +      where finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64) = <class 'numpy.finfo'>(default_scalar_type)
E                +        where <class 'numpy.finfo'> = np.finfo
```