### PR TITLE
Update to main branch

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install DOLFINx
-        uses: jorgensd/actions/install-dolfinx@v0.2.0
+        uses: jorgensd/actions/install-dolfinx@v0.3.0
         with:
           dolfinx: main
           ufl: main

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container: ghcr.io/fenics/dolfinx/dev-env:current-mpich
+    container: ghcr.io/fenics/dolfinx/dev-env:v0.8.0-mpich
     env:
       # Directory that will be published on github pages
       PUBLISH_DIR: ./_build/html
@@ -22,10 +22,10 @@ jobs:
       - name: Install DOLFINx
         uses: jorgensd/actions/install-dolfinx@v0.2.0
         with:
-          dolfinx: main
-          ufl: main
-          ffcx: main
-          basix: main
+          dolfinx: v0.8.0
+          ufl: 2024.1.0.post0
+          ffcx: v0.8.0
+          basix: v0.8.0
           petsc_arch: ${PETSC_ARCH}
 
       - name: Install DOLFINx-MPC (C++)

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install DOLFINx
-        uses: jorgensd/actions/install-dolfinx@v0.3.0
+        uses: jorgensd/actions/install-dolfinx@v0.3
         with:
           dolfinx: main
           ufl: main

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container: ghcr.io/fenics/dolfinx/dev-env:v0.8.0-mpich
+    container: ghcr.io/fenics/dolfinx/dev-env:current-mpich
     env:
       # Directory that will be published on github pages
       PUBLISH_DIR: ./_build/html
@@ -22,10 +22,10 @@ jobs:
       - name: Install DOLFINx
         uses: jorgensd/actions/install-dolfinx@v0.2.0
         with:
-          dolfinx: v0.8.0
-          ufl: 2024.1.0.post0
-          ffcx: v0.8.0
-          basix: v0.8.0
+          dolfinx: main
+          ufl: main
+          ffcx: main
+          basix: main
           petsc_arch: ${PETSC_ARCH}
 
       - name: Install DOLFINx-MPC (C++)

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -35,7 +35,7 @@ jobs:
           cmake --install build-dir
 
       - name: Install DOLFINx-MPC (Python)
-        run: python3 -m pip -v install --config-settings=cmake.build-type="Release" --no-build-isolation  ./python/[docs]
+        run: python3 -m pip -v install --break-system-packages --config-settings=cmake.build-type="Release" --no-build-isolation  ./python/[docs]
 
       - name: Build docs
         run: jupyter book build .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,11 @@
 on:
   push:
-    branches:
-      - "!*"
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - release
+      - main
 
   workflow_dispatch:
 
@@ -43,6 +45,18 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          push: false
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           context: .
           push: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -64,7 +64,7 @@ jobs:
           echo "$HOME/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
 
       - name: Install DOLFINx
-        uses: jorgensd/actions/install-dolfinx@v0.3.0
+        uses: jorgensd/actions/install-dolfinx@v0.3
         with:
           petsc_arch: ${PETSC_ARCH}
           dolfinx: main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -84,7 +84,7 @@ jobs:
           cmake --install build-dir
 
       - name: Install DOLFINx-MPC (Python)
-        run: python3 -m pip -v install --config-settings=cmake.build-type="Release" --no-build-isolation  ./python
+        run: python3 -m pip --break-system-packages -v install --config-settings=cmake.build-type="Release" --no-build-isolation  ./python
 
       - name: Run sonar-scanner
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -64,13 +64,13 @@ jobs:
           echo "$HOME/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
 
       - name: Install DOLFINx
-        uses: jorgensd/actions/install-dolfinx@v0.2.0
+        uses: jorgensd/actions/install-dolfinx@v0.3.0
         with:
           petsc_arch: ${PETSC_ARCH}
-          dolfinx: v0.8.0
-          basix: v0.8.0
-          ufl: 2024.1.0.post0
-          ffcx: v0.8.0
+          dolfinx: main
+          basix: main
+          ufl: main
+          ffcx: main
   
       - name: Run build-wrapper
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,7 +15,7 @@ jobs:
     # avoid running on pull requests from forks
     # which don't have access to secrets
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-    container: ghcr.io/fenics/dolfinx/dev-env:current-mpich
+    container: ghcr.io/fenics/dolfinx/dev-env:v0.8.0-mpich
     env:
       SONAR_SCANNER_VERSION: 5.0.1.3006 # Find the latest version in at: https://github.com/SonarSource/sonar-scanner-cli/tags
       SONAR_SERVER_URL: "https://sonarcloud.io"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,6 +32,9 @@ jobs:
         run: |
           apt-get -y update
           apt-get install unzip
+      - name: Update pip
+        run: |
+          python3 -m pip install --break-system-packages --upgrade pip setuptools
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -87,7 +87,7 @@ jobs:
           cmake --install build-dir
 
       - name: Install DOLFINx-MPC (Python)
-        run: python3 -m pip --break-system-packages -v install --config-settings=cmake.build-type="Release" --no-build-isolation  ./python
+        run: python3 -m pip -v install --break-system-packages --config-settings=cmake.build-type="Release" --no-build-isolation  ./python
 
       - name: Run sonar-scanner
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,7 +15,7 @@ jobs:
     # avoid running on pull requests from forks
     # which don't have access to secrets
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-    container: ghcr.io/fenics/dolfinx/dev-env:v0.8.0-mpich
+    container: ghcr.io/fenics/dolfinx/dev-env:current-mpich
     env:
       SONAR_SCANNER_VERSION: 5.0.1.3006 # Find the latest version in at: https://github.com/SonarSource/sonar-scanner-cli/tags
       SONAR_SERVER_URL: "https://sonarcloud.io"

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -87,7 +87,7 @@ jobs:
           python3 -m pip install --no-cache-dir --no-binary=h5py h5py
 
       - name: Install DOLFINx
-        uses: jorgensd/actions/install-dolfinx@v0.2.0
+        uses: jorgensd/actions/install-dolfinx@v0.3.0
         with:
           dolfinx: ${{ env.DOLFINX_BRANCH }}
           ufl: ${{ env.UFL_BRANCH }}

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -56,7 +56,7 @@ jobs:
       HDF5_DIR: "/usr/local/"
       MPC_BUILD_MODE: ${{ matrix.build_mode }}
       MPC_CMAKE_CXX_FLAGS: "-Wall -Werror -g -pedantic -Ofast -march=native"
-      PYTHONPATH: "/usr/local/dolfinx-${PETSC_TYPE}/lib/python3.10/dist-packages:/usr/local/lib"
+      PYTHONPATH: "/usr/local/dolfinx-${PETSC_TYPE}/lib/python3.12/dist-packages:/usr/local/lib"
       LD_LIBRARY_PATH: "/usr/local/petsc/${PETSC_ARCH}/lib/:/usr/local"
       DEB_PYTHON_INSTALL_LAYOUT: deb_system
     steps:
@@ -87,7 +87,7 @@ jobs:
           python3 -m pip install --no-cache-dir --no-binary=h5py h5py
 
       - name: Install DOLFINx
-        uses: jorgensd/actions/install-dolfinx@v0.3.0
+        uses: jorgensd/actions/install-dolfinx@v0.3
         with:
           dolfinx: ${{ env.DOLFINX_BRANCH }}
           ufl: ${{ env.UFL_BRANCH }}

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Check typing
         run: |
-          python3 -m pip install mypy
+          python3 -m pip install --break-system-packages mypy
           cd python
           python3 -m mypy . --exclude=build
 

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install h5py
         run: |
-          python3 -m pip install --break-system-packages --no-cache-dir --no-binary=h5py h5py
+          python3 -m pip install --no-build-isolation --break-system-packages --no-cache-dir --no-binary=h5py h5py
 
       - name: Install DOLFINx
         uses: jorgensd/actions/install-dolfinx@v0.3

--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -69,7 +69,7 @@ jobs:
           apt-get install -y clang
 
       - name: upgrade pip
-        run: python3 -m pip install --upgrade setuptools pip
+        run: python3 -m pip install --break-system-packages --upgrade setuptools pip
 
       - name: Check formatting
         run: |
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install h5py
         run: |
-          python3 -m pip install --no-cache-dir --no-binary=h5py h5py
+          python3 -m pip install --break-system-packages --no-cache-dir --no-binary=h5py h5py
 
       - name: Install DOLFINx
         uses: jorgensd/actions/install-dolfinx@v0.3
@@ -102,7 +102,7 @@ jobs:
           cmake --install build-dir
 
       - name: Install DOLFINx-MPC (Python)
-        run: python3 -m pip -v install --config-settings=cmake.build-type=${MPC_BUILD_MODE} --no-build-isolation  -e python/[test]
+        run: python3 -m pip -v install --break-system-packages --config-settings=cmake.build-type=${MPC_BUILD_MODE} --no-build-isolation  -e python/[test]
 
       - name: Run tests (serial)
         run: coverage run --rcfile=.coveragerc -m mpi4py -m pytest python/tests/ -vs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,22 +9,21 @@ ARG PYTHON_VERSION=3.12
 ENV HDF5_MPI="ON" \
     HDF5_DIR="/usr/local"
 
-RUN python3 -m pip install -U pip setuptools
+RUN python3 -m pip install --break-system-packages -U pip setuptools
 
 # Install h5py https://github.com/h5py/h5py/issues/2222
-RUN python3 -m pip install --no-cache-dir --no-binary=h5py git+https://github.com/h5py/h5py.git
-RUN python3 -m pip install meshio 
+RUN python3 -m pip install --break-system-packages --no-cache-dir --no-binary=h5py git+https://github.com/h5py/h5py.git
+RUN python3 -m pip install --break-system-packages meshio 
 
 # Copy DOLFINX_MPC source dir
 COPY . dolfinx_mpc
-RUN python3 -m pip install -U pip setuptools
 
 # Install real mode
 RUN . /usr/local/bin/dolfinx-real-mode && \
     . /usr/local/dolfinx-real/lib/dolfinx/dolfinx.conf && \
     cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-real  -DCMAKE_BUILD_TYPE=Developer -B build-dir-real dolfinx_mpc/cpp/ && \
     ninja install -j4  -C build-dir-real && \
-    python3 -m pip install -v --no-build-isolation --check-build-dependencies \
+    python3 -m pip install -v --break-system-packages --no-build-isolation --check-build-dependencies \
     --target /usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir ./dolfinx_mpc/python
 
 # Clean repo to remove build dir from pip
@@ -35,7 +34,7 @@ RUN . /usr/local/bin/dolfinx-complex-mode && \
     . /usr/local/dolfinx-complex/lib/dolfinx/dolfinx.conf && \
     cmake -G Ninja  -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex -DCMAKE_BUILD_TYPE=Developer -B build-dir-complex dolfinx_mpc/cpp/ && \
     ninja install -j4  -C build-dir-complex && \
-    python3 -m pip install -v --no-build-isolation --check-build-dependencies \
+    python3 -m pip install --break-system-packages -v --no-build-isolation --check-build-dependencies \
     --target /usr/local/dolfinx-complex/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir ./dolfinx_mpc/python
 
 WORKDIR /root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/fenics/dolfinx/dolfinx:nightly
 WORKDIR /tmp
 
 # This argument should be the same as what-ever the python version of the dol
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.12
 
 # Set env variables
 ENV HDF5_MPI="ON" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,13 +17,15 @@ RUN python3 -m pip install meshio
 
 # Copy DOLFINX_MPC source dir
 COPY . dolfinx_mpc
+RUN python3 -m pip install -U pip setuptools
 
 # Install real mode
 RUN . /usr/local/bin/dolfinx-real-mode && \
     . /usr/local/dolfinx-real/lib/dolfinx/dolfinx.conf && \
     cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-real  -DCMAKE_BUILD_TYPE=Developer -B build-dir-real dolfinx_mpc/cpp/ && \
     ninja install -j4  -C build-dir-real && \
-    python3 -m pip install -v --no-build-isolation --check-build-dependencies --no-dependencies --target /usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages --config-settings=cmake.build-type=Developer -e dolfinx_mpc/python/[test]
+    python3 -m pip install -v --no-build-isolation --check-build-dependencies \
+    --target /usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir ./dolfinx_mpc/python
 
 # Clean repo to remove build dir from pip
 RUN rm -rf dolfinx_mpc/python/build 
@@ -33,6 +35,7 @@ RUN . /usr/local/bin/dolfinx-complex-mode && \
     . /usr/local/dolfinx-complex/lib/dolfinx/dolfinx.conf && \
     cmake -G Ninja  -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex -DCMAKE_BUILD_TYPE=Developer -B build-dir-complex dolfinx_mpc/cpp/ && \
     ninja install -j4  -C build-dir-complex && \
-    python3 -m pip install -v --no-build-isolation --check-build-dependencies --no-dependencies --target /usr/local/dolfinx-complex/lib/python${PYTHON_VERSION}/dist-packages --config-settings=cmake.build-type=Developer -e dolfinx_mpc/python/[test]
+    python3 -m pip install -v --no-build-isolation --check-build-dependencies \
+    --target /usr/local/dolfinx-complex/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir ./dolfinx_mpc/python
 
 WORKDIR /root

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -59,7 +59,8 @@ target_link_libraries(cpp PRIVATE dolfinx_mpc)
 
 # Check for petsc4py
 execute_process(
-  COMMAND ${Python_EXECUTABLE} -c "import petsc4py; print(petsc4py.get_include())"
+  COMMAND ${Python_EXECUTABLE} -c
+          "import petsc4py; print(petsc4py.get_include())"
   OUTPUT_VARIABLE PETSC4PY_INCLUDE_DIR
   RESULT_VARIABLE PETSC4PY_COMMAND_RESULT
   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -68,8 +69,9 @@ execute_process(
 if(NOT PETSC4PY_COMMAND_RESULT)
   message(STATUS "Found petsc4py include directory at ${PETSC4PY_INCLUDE_DIR}")
   target_include_directories(cpp PRIVATE ${PETSC4PY_INCLUDE_DIR})
+  target_compile_definitions(cpp PRIVATE HAS_PETSC4PY)
 else()
-  message(FATAL_ERROR "petsc4py could not be found.")
+  message(FATAL_ERROR "petsc4py not found.")
 endif()
 
 

--- a/python/benchmarks/bench_contact_3D.py
+++ b/python/benchmarks/bench_contact_3D.py
@@ -211,7 +211,8 @@ def demo_stacked_cubes(theta, ct, noslip, num_refinements, N0, timings=False):
     mesh.name = f"mesh_{celltype}_{theta:.2f}{type_ext:s}"
 
     # Create functionspaces
-    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,))
+    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,),
+                           dtype=default_real_type)
     V = functionspace(mesh, el)
 
     # Define boundary conditions

--- a/python/benchmarks/bench_contact_3D.py
+++ b/python/benchmarks/bench_contact_3D.py
@@ -211,8 +211,9 @@ def demo_stacked_cubes(theta, ct, noslip, num_refinements, N0, timings=False):
     mesh.name = f"mesh_{celltype}_{theta:.2f}{type_ext:s}"
 
     # Create functionspaces
-    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,),
-                           dtype=default_real_type)
+    el = basix.ufl.element(
+        "Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,), dtype=default_real_type
+    )
     V = functionspace(mesh, el)
 
     # Define boundary conditions

--- a/python/benchmarks/bench_elasticity.py
+++ b/python/benchmarks/bench_elasticity.py
@@ -16,7 +16,7 @@ from petsc4py import PETSc
 import basix.ufl
 import h5py
 import numpy as np
-from dolfinx import default_real_type,default_scalar_type
+from dolfinx import default_real_type, default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.fem import (
     Constant,
@@ -49,8 +49,9 @@ def bench_elasticity_one(
         mesh = refine(mesh, redistribute=True)
 
     fdim = mesh.topology.dim - 1
-    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1,
-                           shape=(mesh.geometry.dim,), dtype=default_real_type)
+    el = basix.ufl.element(
+        "Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,), dtype=default_real_type
+    )
     V = functionspace(mesh, el)
 
     # Generate Dirichlet BC on lower boundary (Fixed)

--- a/python/benchmarks/bench_elasticity.py
+++ b/python/benchmarks/bench_elasticity.py
@@ -16,7 +16,7 @@ from petsc4py import PETSc
 import basix.ufl
 import h5py
 import numpy as np
-from dolfinx import default_scalar_type
+from dolfinx import default_real_type,default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.fem import (
     Constant,
@@ -49,7 +49,8 @@ def bench_elasticity_one(
         mesh = refine(mesh, redistribute=True)
 
     fdim = mesh.topology.dim - 1
-    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,))
+    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1,
+                           shape=(mesh.geometry.dim,), dtype=default_real_type)
     V = functionspace(mesh, el)
 
     # Generate Dirichlet BC on lower boundary (Fixed)

--- a/python/benchmarks/bench_elasticity_edge.py
+++ b/python/benchmarks/bench_elasticity_edge.py
@@ -62,8 +62,9 @@ def bench_elasticity_edge(
     ct = CellType.tetrahedron if tetra else CellType.hexahedron
     mesh = create_unit_cube(MPI.COMM_WORLD, N, N, N, ct)
 
-    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), int(degree), shape=(mesh.geometry.dim,),
-                           dtype=default_real_type)
+    el = basix.ufl.element(
+        "Lagrange", mesh.topology.cell_name(), int(degree), shape=(mesh.geometry.dim,), dtype=default_real_type
+    )
     V = functionspace(mesh, el)
 
     # Generate Dirichlet BC (Fixed)

--- a/python/benchmarks/bench_elasticity_edge.py
+++ b/python/benchmarks/bench_elasticity_edge.py
@@ -15,7 +15,7 @@ from petsc4py import PETSc
 import basix.ufl
 import h5py
 import numpy as np
-from dolfinx import default_scalar_type
+from dolfinx import default_real_type, default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.fem import (
     Constant,
@@ -62,7 +62,8 @@ def bench_elasticity_edge(
     ct = CellType.tetrahedron if tetra else CellType.hexahedron
     mesh = create_unit_cube(MPI.COMM_WORLD, N, N, N, ct)
 
-    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), int(degree), shape=(mesh.geometry.dim,))
+    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), int(degree), shape=(mesh.geometry.dim,),
+                           dtype=default_real_type)
     V = functionspace(mesh, el)
 
     # Generate Dirichlet BC (Fixed)

--- a/python/benchmarks/ref_elasticity.py
+++ b/python/benchmarks/ref_elasticity.py
@@ -17,7 +17,7 @@ from petsc4py import PETSc
 import basix.ufl
 import h5py
 import numpy as np
-from dolfinx import default_scalar_type
+from dolfinx import default_real_type, default_scalar_type
 from dolfinx.common import Timer, TimingType, list_timings
 from dolfinx.fem import (
     Constant,
@@ -73,7 +73,8 @@ def ref_elasticity(
         # set_log_level(LogLevel.ERROR)
     N = degree * N
     fdim = mesh.topology.dim - 1
-    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,))
+    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,),
+                           dtype=default_real_type)
     V = functionspace(mesh, el)
 
     # Generate Dirichlet BC on lower boundary (Fixed)

--- a/python/benchmarks/ref_elasticity.py
+++ b/python/benchmarks/ref_elasticity.py
@@ -73,8 +73,9 @@ def ref_elasticity(
         # set_log_level(LogLevel.ERROR)
     N = degree * N
     fdim = mesh.topology.dim - 1
-    el = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,),
-                           dtype=default_real_type)
+    el = basix.ufl.element(
+        "Lagrange", mesh.topology.cell_name(), 1, shape=(mesh.geometry.dim,), dtype=default_real_type
+    )
     V = functionspace(mesh, el)
 
     # Generate Dirichlet BC on lower boundary (Fixed)

--- a/python/demos/demo_elasticity_disconnect.py
+++ b/python/demos/demo_elasticity_disconnect.py
@@ -14,7 +14,7 @@ from mpi4py import MPI
 import basix.ufl
 import gmsh
 import numpy as np
-from dolfinx import default_scalar_type
+from dolfinx import default_real_type, default_scalar_type
 from dolfinx.fem import Constant, Function, dirichletbc, functionspace, locate_dofs_topological
 from dolfinx.io import XDMFFile, gmshio
 from ufl import (
@@ -224,6 +224,7 @@ V_out = functionspace(
         mesh.geometry.cmap.degree,
         lagrange_variant=basix.LagrangeVariant(mesh.geometry.cmap.variant),
         shape=(V.dofmap.bs,),
+        dtype=default_real_type,
     ),
 )
 u_out = Function(V_out)

--- a/python/demos/demo_stokes.py
+++ b/python/demos/demo_stokes.py
@@ -21,7 +21,7 @@ import basix.ufl
 import gmsh
 import numpy as np
 import scipy.sparse.linalg
-from dolfinx import common, default_scalar_type, fem, io
+from dolfinx import common, default_real_type, default_scalar_type, fem, io
 from dolfinx.io import gmshio
 from numpy.typing import NDArray
 from ufl import (
@@ -141,8 +141,8 @@ fdim = mesh.topology.dim - 1
 # The next step is the create the function spaces for the fluid velocit and pressure.
 # We will use a mixed-formulation, and we use `basix.ufl` to create the Taylor-Hood finite element pair
 
-P2 = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 2, shape=(mesh.geometry.dim,))
-P1 = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1)
+P2 = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 2, shape=(mesh.geometry.dim,), dtype=default_real_type)
+P1 = basix.ufl.element("Lagrange", mesh.topology.cell_name(), 1, dtype=default_real_type)
 
 TH = basix.ufl.mixed_element([P2, P1])
 W = fem.functionspace(mesh, TH)

--- a/python/demos/demo_stokes_nest.py
+++ b/python/demos/demo_stokes_nest.py
@@ -22,7 +22,7 @@ import gmsh
 import numpy as np
 import scipy.sparse.linalg
 import ufl
-from dolfinx import default_scalar_type
+from dolfinx import default_real_type, default_scalar_type
 from dolfinx.io import gmshio
 from ufl.core.expr import Expr
 
@@ -120,8 +120,8 @@ fdim = mesh.topology.dim - 1
 
 # Create the function space
 cellname = mesh.ufl_cell().cellname()
-Ve = basix.ufl.element(basix.ElementFamily.P, cellname, 2, shape=(mesh.geometry.dim,))
-Qe = basix.ufl.element(basix.ElementFamily.P, cellname, 1)
+Ve = basix.ufl.element(basix.ElementFamily.P, cellname, 2, shape=(mesh.geometry.dim,), dtype=default_real_type)
+Qe = basix.ufl.element(basix.ElementFamily.P, cellname, 1, dtype=default_real_type)
 
 V = dolfinx.fem.functionspace(mesh, Ve)
 Q = dolfinx.fem.functionspace(mesh, Qe)

--- a/python/dolfinx_mpc/mpc.cpp
+++ b/python/dolfinx_mpc/mpc.cpp
@@ -33,6 +33,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
+#include <petsc4py/petsc4py.h>
 #include <petscmat.h>
 #include <petscvec.h>
 namespace nb = nanobind;

--- a/python/dolfinx_mpc/utils/mpc_utils.py
+++ b/python/dolfinx_mpc/utils/mpc_utils.py
@@ -204,7 +204,7 @@ def rigid_motions_nullspace(V: _fem.FunctionSpace):
         b.scatter_forward()
 
     _la.orthonormalize(nullspace_basis)
-    assert _la.is_orthonormal(nullspace_basis)
+    assert _la.is_orthonormal(nullspace_basis, np.finfo(_x.x.array.dtype).eps)
     local_size = V.dofmap.index_map.size_local * V.dofmap.index_map_bs
     basis_petsc = [
         PETSc.Vec().createWithArray(x[:local_size], bsize=gdim, comm=V.mesh.comm)  # type: ignore

--- a/python/dolfinx_mpc/utils/mpc_utils.py
+++ b/python/dolfinx_mpc/utils/mpc_utils.py
@@ -200,6 +200,8 @@ def rigid_motions_nullspace(V: _fem.FunctionSpace):
         basis[4][dofs[2]] = -x0
         basis[5][dofs[2]] = x1
         basis[5][dofs[1]] = -x2
+    for b in nullspace_basis:
+        b.scatter_forward()
 
     _la.orthonormalize(nullspace_basis)
     assert _la.is_orthonormal(nullspace_basis)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
       "cffi",
       "petsc4py",
       "mpi4py",
-      "fenics-dolfinx>=0.8.0",
+      "fenics-dolfinx>0.8.0",
 ]
 
 [project.optional-dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
       "cffi",
       "petsc4py",
       "mpi4py",
-      "fenics-dolfinx>=0.8.0.dev0,<0.9.0",
+      "fenics-dolfinx>=0.8.0",
 ]
 
 [project.optional-dependencies]

--- a/python/tests/test_nonlinear_assembly.py
+++ b/python/tests/test_nonlinear_assembly.py
@@ -199,8 +199,7 @@ def test_homogenize(tensor_order, poly_order):
         pytest.xfail("Unknown tensor order")
 
     cellname = mesh.ufl_cell().cellname()
-    el = basix.ufl.element(basix.ElementFamily.P, cellname, poly_order, shape=shape,
-                           dtype=mesh.geometry.x.dtype)
+    el = basix.ufl.element(basix.ElementFamily.P, cellname, poly_order, shape=shape, dtype=mesh.geometry.x.dtype)
 
     V = dolfinx.fem.functionspace(mesh, el)
 

--- a/python/tests/test_nonlinear_assembly.py
+++ b/python/tests/test_nonlinear_assembly.py
@@ -199,7 +199,8 @@ def test_homogenize(tensor_order, poly_order):
         pytest.xfail("Unknown tensor order")
 
     cellname = mesh.ufl_cell().cellname()
-    el = basix.ufl.element(basix.ElementFamily.P, cellname, poly_order, shape=shape)
+    el = basix.ufl.element(basix.ElementFamily.P, cellname, poly_order, shape=shape,
+                           dtype=mesh.geometry.x.dtype)
 
     V = dolfinx.fem.functionspace(mesh, el)
 

--- a/python/tests/test_rectangular_assembly.py
+++ b/python/tests/test_rectangular_assembly.py
@@ -48,15 +48,16 @@ def test_mixed_element(cell_type, ghost_mode):
 
     # Create the function space
     cellname = mesh.ufl_cell().cellname()
-    Ve = basix.ufl.element(basix.ElementFamily.P, cellname, 2, shape=(mesh.geometry.dim,))
-    Qe = basix.ufl.element(basix.ElementFamily.P, cellname, 1)
+    Ve = basix.ufl.element(basix.ElementFamily.P, cellname, 2, shape=(mesh.geometry.dim,),
+                           dtype=dolfinx.default_real_type)
+    Qe = basix.ufl.element(basix.ElementFamily.P, cellname, 1, dtype=dolfinx.default_real_type)
 
     V = dolfinx.fem.functionspace(mesh, Ve)
     Q = dolfinx.fem.functionspace(mesh, Qe)
     W = dolfinx.fem.functionspace(mesh, basix.ufl.mixed_element([Ve, Qe]))
 
     inlet_velocity = dolfinx.fem.Function(V)
-    inlet_velocity.interpolate(lambda x: np.zeros((mesh.geometry.dim, x[0].shape[0]), dtype=np.double))
+    inlet_velocity.interpolate(lambda x: np.zeros((mesh.geometry.dim, x[0].shape[0]), dtype=dolfinx.default_scalar_type))
     inlet_velocity.x.scatter_forward()
 
     # -- Nested assembly

--- a/python/tests/test_rectangular_assembly.py
+++ b/python/tests/test_rectangular_assembly.py
@@ -48,8 +48,9 @@ def test_mixed_element(cell_type, ghost_mode):
 
     # Create the function space
     cellname = mesh.ufl_cell().cellname()
-    Ve = basix.ufl.element(basix.ElementFamily.P, cellname, 2, shape=(mesh.geometry.dim,),
-                           dtype=dolfinx.default_real_type)
+    Ve = basix.ufl.element(
+        basix.ElementFamily.P, cellname, 2, shape=(mesh.geometry.dim,), dtype=dolfinx.default_real_type
+    )
     Qe = basix.ufl.element(basix.ElementFamily.P, cellname, 1, dtype=dolfinx.default_real_type)
 
     V = dolfinx.fem.functionspace(mesh, Ve)
@@ -57,7 +58,9 @@ def test_mixed_element(cell_type, ghost_mode):
     W = dolfinx.fem.functionspace(mesh, basix.ufl.mixed_element([Ve, Qe]))
 
     inlet_velocity = dolfinx.fem.Function(V)
-    inlet_velocity.interpolate(lambda x: np.zeros((mesh.geometry.dim, x[0].shape[0]), dtype=dolfinx.default_scalar_type))
+    inlet_velocity.interpolate(
+        lambda x: np.zeros((mesh.geometry.dim, x[0].shape[0]), dtype=dolfinx.default_scalar_type)
+    )
     inlet_velocity.x.scatter_forward()
 
     # -- Nested assembly


### PR DESCRIPTION
Moving CI to ubuntu 22.04/python 3.12:
- `--break-system-packages` and `--no-build-isolation` needed for most `python3 -m pip install` commands
- Run docker build on pull request to main and release to catch build issues
- Bump `jorgensd/actions/install-dolfinx` to v0.3

Cmake/nanobind:
- PETSc/petsc4py now optional, extra cmake code required

Dolfinx/basix:
- `dtype`: Consistently added to `basix.ufl.element` to work on single precision builds
- `nullspace` computation for rigid motions updated, ref: https://github.com/FEniCS/dolfinx/pull/3184