### PR TITLE
Add scipy to docs dependency due to failing build

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-docs = ['jupyter-book', 'jupytext']
+docs = ['jupyter-book', 'jupytext', "scipy"]
 lint = ["ruff", "mypy"]
 optional = ["numba"]
 test = ["pytest", "coverage", "scipy"]


### PR DESCRIPTION
The demo in the docs did not build correctly due to missing `scipy` dependency (see screenshot and link here: https://jsdokken.com/dolfinx_mpc/python/demos/demo_stokes.html).
![Screenshot 2024-06-23 at 10 55 28](https://github.com/jorgensd/dolfinx_mpc/assets/2010323/a9f6f2d8-e6fc-4858-89e6-a9440405610e)

In this PR I add `scipy` as a docs dependency. 