### PR TITLE
Use dev-env as base container

### DIFF
--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/fenics/dolfinx/dolfinx:nightly
+    container: ghcr.io/fenics/dolfinx/dev-env:current-mpich
 
     strategy:
       matrix:


### PR DESCRIPTION
All `FEniCS` dependencies are built anyway. No need to use container that comes with pre installed versions.