### PR TITLE
Remvoe explicit choice of build parallelization

### DIFF
--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install DOLFINx-MPC (C++)
         run: |
           cmake -G Ninja -B build-dir -DCMAKE_BUILD_TYPE=${MPC_BUILD_MODE} -DCMAKE_CXX_FLAGS="${MPC_CMAKE_CXX_FLAGS}" -S cpp/
-          cmake --build build-dir --parallel 3
+          cmake --build build-dir
           cmake --install build-dir
 
       - name: Install DOLFINx-MPC (Python)


### PR DESCRIPTION
Github runners have been upgraded see [here](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) and `ninja` picks already full parallel by default.