### PR TITLE
Enhance equations rendering in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ where $I_N$ is the set of degrees of freedom to constrain.
 This can be used to for instance enforce slip conditions strongly.
 
 Consider a linear system of the form 
-$Au=b$, with the additional constraints written on the form $K\hat u=u$, where $K$ is a prolongation matrix, $\hat u$ is the vector of unknowns excluding the $I_N$ entries. 
+$Au=b$, with the additional constraints written on the form ${K\hat{u}=u}$, where $K$ is a prolongation matrix, $\hat{u}$ is the vector of unknowns excluding the $I_N$ entries. 
 
 We then solve the system 
-$K^T A K \hat u = K^T b$, where $K^T A K$ is symmetric if $A$ was symmetric.
-(For complex numbers, we use the Hermitian transpose and solve the system $\overline{K^T} A K \hat u = \overline{K^T} b$, where $\overline{K^T}$ is the complex conjugate of $K^T$, and $\overline{K^T} A K$ is Hermitian if $A$ was Hermitian.)
+${K^T A K \hat{u} = K^T b}$, where $K^T A K$ is symmetric if $A$ was symmetric.
+For complex numbers, we use the Hermitian transpose and solve the system ${\overline{K^T} A K \hat{u} = \overline{K^T} b}$, where $\overline{K^T}$ is the complex conjugate of $K^T$, and $\overline{K^T} A K$ is Hermitian if $A$ was Hermitian.
 
 If we include boundary conditions on the form $u=g$, we 
 assemble the system
-$K^TAK\hat u = K^T(b-A\hat g)$ where $A\hat g$ is an extension of the boundary condition $g$ to all degrees of freedom.
+${K^TAK\hat{u} = K^T(b-A\hat{g})}$ where ${A\hat{g}}$ is an extension of the boundary condition $g$ to all degrees of freedom.
 
 The library performs custom matrix and vector assembly adding the extra constraints to the set of linear equations. All assemblies are local to the process, and no MPI communication except when setting up the multi point constraints.
 


### PR DESCRIPTION
The rendering of LaTeX equations with `\hat` in the README file is a bit weird. Adding braces at both ends of the equation fix it. I suggest these modifications to improve the readability of the README.