### PR TITLE
Update test_mpc.yml

### DIFF
--- a/.github/workflows/test_mpc.yml
+++ b/.github/workflows/test_mpc.yml
@@ -95,6 +95,9 @@ jobs:
           basix: ${{ env.BASIX_BRANCH }}
           ffcx: ${{ env.FFCX_BRANCH }}
           petsc_arch: ${{ env.PETSC_ARCH }}
+      - name: Restrict CFFI
+        run:
+           python3 -m pip install --no-build-isolation cffi<1.17
 
       - name: Install DOLFINx-MPC (C++)
         run: |


### PR DESCRIPTION
Due to unpinning cffi in DOLFINx (https://github.com/FEniCS/dolfinx/pull/3635) , various tests fail: https://github.com/jorgensd/dolfinx_mpc/actions/runs/13369605306/job/37336342794
Alternative option is to mark all tests that uses complex mode to fail with CFFI version
