### PR TITLE
Zero out  backsubstitution

### DIFF
--- a/cpp/MultiPointConstraint.h
+++ b/cpp/MultiPointConstraint.h
@@ -130,6 +130,9 @@ public:
   {
     for (auto slave : _slaves)
     {
+      // Zero out intial data in slave dof
+      vector[slave] = 0.0;
+      // Accumulate master contributions
       auto masters = _master_map->links(slave);
       auto coeffs = _coeff_map->links(slave);
       assert(masters.size() == coeffs.size());


### PR DESCRIPTION
Zero out prior to accumulation.

Made visible in: https://fenicsproject.discourse.group/t/convergence-issue-in-periodic-bcs-for-poisson-eq-in-1d/17129