### PR TITLE
Fix slicing of scipy csr arrays (scipy>=1.17.0) causing memory overflow

### DIFF
--- a/python/demos/demo_periodic3d_topological.py
+++ b/python/demos/demo_periodic3d_topological.py
@@ -115,10 +115,9 @@ def demo_periodic3D(celltype: CellType):
     )
 
     rhs = inner(f, v) * dx
-
     petsc_options: Dict[str, Union[str, float, int]]
     if complex_mode or default_scalar_type == np.float32:
-        petsc_options = {"ksp_type": "preonly", "pc_type": "lu"}
+        petsc_options = {"ksp_type": "preonly", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps"}
     else:
         petsc_options = {
             "ksp_type": "cg",

--- a/python/src/dolfinx_mpc/utils/test.py
+++ b/python/src/dolfinx_mpc/utils/test.py
@@ -231,8 +231,10 @@ def compare_mpc_lhs(
         # Remove identity rows of MPC matrix
         all_cols = np.arange(V.dofmap.index_map.size_global * V.dofmap.index_map_bs)
 
-        cols_except_slaves = np.flatnonzero(np.isin(all_cols, glob_slaves, invert=True).astype(np.int32))
-        mpc_without_slaves = A_mpc_csr[cols_except_slaves[:, None], cols_except_slaves]
+        # Scipy >=1.17.0 requires special way of doing slicing to avoid memory overflow
+        # https://github.com/scipy/scipy/issues/24339
+        free_mask = np.flatnonzero(np.isin(all_cols, glob_slaves, invert=True).astype(np.int32))
+        mpc_without_slaves = A_mpc_csr[free_mask, :][:, free_mask]
 
         # Compute difference
         compare_CSR(KTAK, mpc_without_slaves, atol=atol)


### PR DESCRIPTION
This is only used in testing, so not required to backport.

Resolves: https://github.com/jorgensd/dolfinx_mpc/issues/212
Additionally sets mumps as LU backend