### PR TITLE
Rewrite create sparsity pattern to be correct for non-square systems

### DIFF
--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -417,7 +417,6 @@ dolfinx::la::SparsityPattern create_sparsity_pattern(
     const auto& col_master_map = mpc_off_axis->masters();
     // Data structures used for insert
     std::array<std::int32_t, 1> master_block;
-    std::array<std::int32_t, 1> other_master_block;
 
     // Map from cell index (local to mpc) to slave indices in the cell
     const std::shared_ptr<const dolfinx::graph::AdjacencyList<std::int32_t>>
@@ -477,13 +476,6 @@ dolfinx::la::SparsityPattern create_sparsity_pattern(
       {
         master_block[0] = flattened_masters[j];
         pattern_inserter(pattern, std::span(master_block), col_slave_dofs);
-        // Add sparsity pattern for all master dofs of any slave on this cell
-        for (std::size_t k = j + 1; k < flattened_masters.size(); ++k)
-        {
-          other_master_block[0] = flattened_masters[k];
-          master_inserter(pattern, std::span(other_master_block),
-                          std::span(master_block));
-        }
       }
     }
   };

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -402,19 +402,40 @@ dolfinx::la::SparsityPattern create_sparsity_pattern(
   ///  Create and build sparsity pattern for original form. Should be
   ///  equivalent to calling create_sparsity_pattern(Form a)
   build_standard_pattern<T>(pattern, a);
-  spdlog::debug("Build new pattern\n");
+
+  // Create a list of all master dofs for a set of slaves,
+  // up to block-size
+
+  auto expand_masters_for_slave
+      = [](std::vector<std::int32_t>& master_dofs, std::size_t bs,
+           const dolfinx::graph::AdjacencyList<std::int32_t>& master_map,
+           std::span<const std::int32_t> slaves)
+  {
+    for (auto slave : slaves)
+    {
+      for (auto master : master_map.links(slave))
+      {
+        const std::div_t div = std::div(master, bs);
+        master_dofs.push_back(div.quot);
+      }
+    }
+  };
 
   // Arrays replacing slave dof with master dof in sparsity pattern
-  auto pattern_populator =
-      [](dolfinx::la::SparsityPattern& pattern,
-         const std::shared_ptr<dolfinx_mpc::MultiPointConstraint<T, U>> mpc_row,
-         const std::shared_ptr<dolfinx_mpc::MultiPointConstraint<T, U>> mpc_col)
+  auto pattern_populator
+      = [expand_masters_for_slave](
+            dolfinx::la::SparsityPattern& pattern,
+            const std::shared_ptr<dolfinx_mpc::MultiPointConstraint<T, U>>
+                mpc_row,
+            const std::shared_ptr<dolfinx_mpc::MultiPointConstraint<T, U>>
+                mpc_col)
   {
     const auto& V_row = mpc_row->function_space();
     const auto& V_col = mpc_col->function_space();
+    const auto& row_master_map = mpc_row->masters();
     const auto& col_master_map = mpc_col->masters();
-    // Data structures used for insert
-    std::array<std::int32_t, 1> master_block;
+    std::size_t bs_row = V_row->dofmap()->index_map_bs();
+    std::size_t bs_col = V_col->dofmap()->index_map_bs();
 
     // Map from cell index (local to mpc_row) to slave indices in the cell
     const std::shared_ptr<const dolfinx::graph::AdjacencyList<std::int32_t>>
@@ -425,55 +446,41 @@ dolfinx::la::SparsityPattern create_sparsity_pattern(
 
     // For each cell (local to process) having a slave, get all slaves in main
     // constraint, and all dofs in off-axis constraint in the cell
-    for (std::int32_t i = 0; i < cell_to_row_slaves->num_nodes(); ++i)
+    for (std::int32_t c = 0; c < cell_to_row_slaves->num_nodes(); ++c)
     {
       // Get column cell dofs
       std::span<const std::int32_t> col_cell_dofs
-          = V_col->dofmap()->cell_dofs(i);
+          = V_col->dofmap()->cell_dofs(c);
       std::vector<std::int32_t> col_slave_dofs;
-      std::ranges::copy(col_cell_dofs.begin(), col_cell_dofs.end(),
-                        std::back_inserter(col_slave_dofs));
+      col_slave_dofs.reserve(col_cell_dofs.size());
+      std::ranges::copy(col_cell_dofs, std::back_inserter(col_slave_dofs));
 
       // Add additional master dofs for that cell
-      std::span<const std::int32_t> col_slaves = cell_to_col_slaves->links(i);
-      for (auto cs : col_slaves)
-      {
-        for (auto col_master : mpc_col->masters()->links(cs))
-        {
-          const std::div_t div
-              = std::div(col_master, V_col->dofmap()->index_map_bs());
-          col_slave_dofs.push_back(div.quot);
-        }
-      }
+      std::span<const std::int32_t> col_slaves = cell_to_col_slaves->links(c);
+
+      expand_masters_for_slave(col_slave_dofs, bs_col, *col_master_map,
+                               col_slaves);
 
       // Insert modified columns for non-slave rows
       // Here we insert abit broad for now
       // FIXME: Could remove dofs that are slaves
       std::span<const std::int32_t> row_cell_dofs
-          = V_row->dofmap()->cell_dofs(i);
+          = V_row->dofmap()->cell_dofs(c);
       pattern.insert(row_cell_dofs, col_slave_dofs);
 
       // Map slave dofs
-      std::span<const std::int32_t> slaves = cell_to_row_slaves->links(i);
+      std::span<const std::int32_t> slaves = cell_to_row_slaves->links(c);
 
       // Arrays for flattened master slave data
       std::vector<std::int32_t> flattened_masters;
       flattened_masters.reserve(slaves.size());
-
-      // For each slave find all master degrees of freedom and flatten them
-      for (auto slave : slaves)
-      {
-        for (auto master : mpc_row->masters()->links(slave))
-        {
-          const std::div_t div
-              = std::div(master, V_row->dofmap()->index_map_bs());
-          flattened_masters.push_back(div.quot);
-        }
-      }
+      expand_masters_for_slave(flattened_masters, bs_row, *row_master_map,
+                               slaves);
       pattern.insert(flattened_masters, col_slave_dofs);
     }
   };
 
+  spdlog::debug("Build new pattern\n");
   pattern_populator(pattern, mpc0, mpc1);
 
   return pattern;

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -433,8 +433,8 @@ dolfinx::la::SparsityPattern create_sparsity_pattern(
       std::span<const std::int32_t> col_cell_dofs
           = V_off_axis->dofmap()->cell_dofs(i);
       std::vector<std::int32_t> col_slave_dofs;
-      std::copy(col_cell_dofs.begin(), col_cell_dofs.end(),
-                std::back_inserter(col_slave_dofs));
+      std::ranges::copy(col_cell_dofs.begin(), col_cell_dofs.end(),
+                        std::back_inserter(col_slave_dofs));
 
       // Add additional master dofs for that cell
       std::span<const std::int32_t> col_slaves = cell_to_col_slaves->links(i);

--- a/python/tests/test_multispace_mpc.py
+++ b/python/tests/test_multispace_mpc.py
@@ -52,7 +52,7 @@ def test_multiple_mpc_spaces_sparsity(cell_type, deg, N):
     v, q = ufl.TestFunction(V), ufl.TestFunction(Q)
 
     # Weak statementmpc_u,
-    a01 = v * p * ufl.dx
+    a01 = ufl.inner(p, v) * ufl.dx
     form_01 = fem.form(a01)
     mpcs_01 = [mpc_u, mpc_p]
 
@@ -64,7 +64,7 @@ def test_multiple_mpc_spaces_sparsity(cell_type, deg, N):
 
     assert p0.num_nonzeros == p1.num_nonzeros
 
-    a10 = u * q * ufl.dx
+    a10 = ufl.inner(u, q) * ufl.dx
     form_10 = fem.form(a10)
 
     mpcs_10 = [mpc_p, mpc_u]

--- a/python/tests/test_multispace_mpc.py
+++ b/python/tests/test_multispace_mpc.py
@@ -1,0 +1,77 @@
+from mpi4py import MPI
+
+import numpy as np
+import pytest
+import ufl
+from basix.ufl import element
+from dolfinx import fem, mesh
+
+import dolfinx_mpc
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [mesh.CellType.quadrilateral, mesh.CellType.hexahedron, mesh.CellType.tetrahedron, mesh.CellType.triangle],
+)
+@pytest.mark.parametrize("deg", [1, 2, 4])
+@pytest.mark.parametrize("N", [3, 5, 8])
+def test_multiple_mpc_spaces_sparsity(cell_type, deg, N):
+    """
+    Test of sparsity pattern of square matrices with mpcs on two distinct spaces
+    """
+    cd = mesh.cell_dim(cell_type)
+    Ns = np.full(cd, N, dtype=int)
+    if cd == 2:
+        mesh_constructor = mesh.create_unit_square
+    elif cd == 3:
+        mesh_constructor = mesh.create_unit_cube
+    domain = mesh_constructor(MPI.COMM_WORLD, *Ns, cell_type=cell_type)
+
+    V = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), deg))
+    Q = V.clone()
+
+    def periodic_boundary(x):
+        return np.logical_or(np.isclose(x[0], 1), np.isclose(x[2], 1))
+
+    def periodic_map(x):
+        out = x.copy()
+        out[0][np.isclose(x[0], 1).nonzero()] -= 1
+        out[domain.geometry.dim - 1][np.isclose(x[2], 1).nonzero()] -= 1
+        return out
+
+    mpc_u = dolfinx_mpc.MultiPointConstraint(V)
+    mpc_u.create_periodic_constraint_geometrical(V, periodic_boundary, periodic_map, [])
+    mpc_u.finalize()
+
+    mpc_p = dolfinx_mpc.MultiPointConstraint(Q)
+    mpc_p.create_periodic_constraint_geometrical(Q, periodic_boundary, periodic_map, [])
+    mpc_p.finalize()
+
+    # Stokes weak form
+    u, p = ufl.TrialFunction(V), ufl.TrialFunction(Q)
+    v, q = ufl.TestFunction(V), ufl.TestFunction(Q)
+
+    # Weak statementmpc_u,
+    a01 = v * p * ufl.dx
+    form_01 = fem.form(a01)
+    mpcs_01 = [mpc_u, mpc_p]
+
+    p0 = dolfinx_mpc.create_sparsity_pattern(form_01, mpcs_01)
+    p0.finalize()
+
+    p1 = dolfinx_mpc.create_sparsity_pattern(form_01, [mpc_u, mpc_u])
+    p1.finalize()
+
+    assert p0.num_nonzeros == p1.num_nonzeros
+
+    a10 = u * q * ufl.dx
+    form_10 = fem.form(a10)
+
+    mpcs_10 = [mpc_p, mpc_u]
+    p0 = dolfinx_mpc.create_sparsity_pattern(form_10, mpcs_10)
+    p0.finalize()
+
+    p1 = dolfinx_mpc.create_sparsity_pattern(form_10, [mpc_u, mpc_u])
+    p1.finalize()
+
+    assert p0.num_nonzeros == p1.num_nonzeros

--- a/python/tests/test_multispace_mpc.py
+++ b/python/tests/test_multispace_mpc.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element
-from dolfinx import fem, mesh
+from dolfinx import default_real_type, fem, mesh
 
 import dolfinx_mpc
 
@@ -27,7 +27,7 @@ def test_multiple_mpc_spaces_sparsity(cell_type, deg, N):
         mesh_constructor = mesh.create_unit_cube
     domain = mesh_constructor(MPI.COMM_WORLD, *Ns, cell_type=cell_type)
 
-    V = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), deg))
+    V = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), deg, dtype=default_real_type))
     Q = V.clone()
 
     def periodic_boundary(x):

--- a/python/tests/test_stokes_channelflow.py
+++ b/python/tests/test_stokes_channelflow.py
@@ -144,14 +144,6 @@ def test_stokes_channelflow(cell_type, els, order):
     mpc_u.backsubstitution(uh)
     mpc_p.backsubstitution(ph)
 
-    # Export solution
-    uh.name = "velocity"
-    ph.name = "pressure"
-    with io.VTXWriter(domain.comm, "/app/stokes_channelflow_u.bp", uh, engine="BP4") as vtx:
-        vtx.write(0.0)
-    with io.VTXWriter(domain.comm, "/app/stokes_channelflow_p.bp", ph, engine="BP4") as vtx:
-        vtx.write(0.0)
-
     # Verify solution: Poiseuille flow u_x = (dp/dx) * (1/(2*mu)) * y * (H - y)
     # For our parameters: mu=1, dp/dx=-1, H=1
     # u_x = -(-1) * (1/2) * y * (1 - y) = 0.5 * y * (1 - y)

--- a/python/tests/test_stokes_channelflow.py
+++ b/python/tests/test_stokes_channelflow.py
@@ -14,8 +14,8 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element
-from dolfinx import default_scalar_type, io, la
-from dolfinx.mesh import create_unit_cube, CellType
+from dolfinx import default_scalar_type, la
+from dolfinx.mesh import CellType, create_unit_cube
 
 import dolfinx_mpc
 
@@ -25,36 +25,36 @@ import dolfinx_mpc
 @pytest.mark.parametrize("order", [2, 3])
 def test_stokes_channelflow(cell_type, els, order):
     """Test 3D Stokes channel flow with periodic BCs and nested assembly and Taylor-Hood elements.
-    
+
     The analytical solution for Poiseuille flow between parallel plates is:
     u_x = (dp/dx) * (1/(2*mu)) * y * (H - y)
     where H is the channel height, dp/dx is the pressure gradient enforced as a body force, mu is viscosity.
     """
-    
+
     # Cube mesh
     domain = create_unit_cube(MPI.COMM_WORLD, els, els, els, cell_type=cell_type)
-    
+
     # Function spaces: Taylor-Hood
     V = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order, shape=(3,)))
-    Q = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order-1))
-    
+    Q = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order - 1))
+
     # Wall BCs (top/bottom y={0,1})
     wall_facets = mesh.locate_entities_boundary(
         domain, 2, lambda x: np.logical_or(np.isclose(x[1], 0), np.isclose(x[1], 1))
     )
     wall_dofs = fem.locate_dofs_topological(V, 2, wall_facets)
     bc = fem.dirichletbc(np.zeros(3, dtype=default_scalar_type), wall_dofs, V)
-    
+
     # Periodicity definition (x and z directions)
     def periodic_boundary(x):
         return np.logical_or(np.isclose(x[0], 1), np.isclose(x[2], 1))
-    
+
     def periodic_map(x):
         out = x.copy()
         out[0][np.isclose(x[0], 1).nonzero()] -= 1
         out[2][np.isclose(x[2], 1).nonzero()] -= 1
         return out
-    
+
     # Create MPCs for velocity and pressure
     mpc_u = dolfinx_mpc.MultiPointConstraint(V)
     mpc_u.create_periodic_constraint_geometrical(V, periodic_boundary, periodic_map, [bc])
@@ -62,54 +62,54 @@ def test_stokes_channelflow(cell_type, els, order):
     mpc_p = dolfinx_mpc.MultiPointConstraint(Q)
     mpc_p.create_periodic_constraint_geometrical(Q, periodic_boundary, periodic_map, [])
     mpc_p.finalize()
-    
+
     # Stokes weak form
     u = ufl.TrialFunction(V)
     p = ufl.TrialFunction(Q)
     v = ufl.TestFunction(V)
     q = ufl.TestFunction(Q)
-    
+
     # Viscosity and forcing
     mu = fem.Constant(domain, default_scalar_type(1.0))
     dp_dx = fem.Constant(domain, default_scalar_type(1.0))  # Pressure gradient in x-direction
     f = ufl.as_vector([dp_dx, 0.0, 0.0])
-    
+
     # Weak statement
     a00 = mu * ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
     a01 = -ufl.div(v) * p * ufl.dx
     a10 = -q * ufl.div(u) * ufl.dx
     L0 = ufl.inner(f, v) * ufl.dx
     L1 = ufl.ZeroBaseForm((q,))
-    
+
     forms = fem.form([[a00, a01], [a10, None]])
     rhs_forms = fem.form([L0, L1])
-    
+
     # Assemble - THIS IS WHERE THE BUG OCCURS with MPI and hexahedral cells
     A = dolfinx_mpc.create_matrix_nest(forms, constraints=[mpc_u, mpc_p])
     dolfinx_mpc.assemble_matrix_nest(A, forms, constraints=[mpc_u, mpc_p], bcs=[bc])
     A.assemble()
-    
+
     b = dolfinx_mpc.create_vector_nest(rhs_forms, constraints=[mpc_u, mpc_p])
     dolfinx_mpc.assemble_vector_nest(b, rhs_forms, constraints=[mpc_u, mpc_p])
-    
+
     # Apply lifting for boundary conditions
     bcs_block = fem.bcs_by_block(fem.extract_function_spaces(forms, 1), [bc])
     dolfinx_mpc.apply_lifting(b, forms, bcs_block, constraint=[mpc_u, mpc_p])
-    
+
     # Ghost update after lifting
     for b_sub in b.getNestSubVecs():
         b_sub.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-    
+
     # Set BC values in RHS
     bcs0 = fem.bcs_by_block(fem.extract_function_spaces(rhs_forms), [bc])
     fem.petsc.set_bc(b, bcs0)
-    
+
     # Setup Minres solver
     ksp = PETSc.KSP().create(domain.comm)
     ksp.setOperators(A)
     ksp.setType("minres")
     ksp.setTolerances(rtol=1e-8, atol=1e-10)
-    
+
     # Setup preconditioning
     pc = ksp.getPC()
     pc.setType("fieldsplit")
@@ -122,14 +122,14 @@ def test_stokes_channelflow(cell_type, els, order):
     ksp_u.getPC().setFactorSolverType("mumps")
     ksp_p.setType("preonly")
     ksp_p.getPC().setType("jacobi")
-    
+
     # Finalize KSP setup
     ksp.setFromOptions()
-    
+
     # Create solution functions
     uh = fem.Function(mpc_u.function_space)
     ph = fem.Function(mpc_p.function_space)
-    
+
     # Solve the system
     x = b.duplicate()
     ksp.solve(b, x)
@@ -139,7 +139,7 @@ def test_stokes_channelflow(cell_type, els, order):
         scatter_mode=PETSc.ScatterMode.FORWARD,  # type: ignore
     )  # type: ignore
     fem.petsc.assign(x, [uh, ph])
-    
+
     # Apply backsubstitution for MPCs
     mpc_u.backsubstitution(uh)
     mpc_p.backsubstitution(ph)
@@ -148,24 +148,24 @@ def test_stokes_channelflow(cell_type, els, order):
     # For our parameters: mu=1, dp/dx=-1, H=1
     # u_x = -(-1) * (1/2) * y * (1 - y) = 0.5 * y * (1 - y)
     # Maximum velocity at y=0.5: u_max = 0.5 * 0.5 * 0.5 = 0.125
-    
+
     # Create analytical solution function
     def u_exact_expr(x):
         """Exact solution for Poiseuille flow"""
         values = np.zeros((3, x.shape[1]))
         values[0] = 0.5 * x[1] * (1.0 - x[1])  # u_x component
         return values
-    
+
     u_exact = fem.Function(V)
     u_exact.interpolate(u_exact_expr)
-    
+
     # Compute error
     error_u = uh.x.array - u_exact.x.array
     error_norm = np.linalg.norm(error_u)
-    error_norm_global = domain.comm.allreduce(error_norm**2, op=MPI.SUM)**0.5
-    
+    error_norm_global = domain.comm.allreduce(error_norm**2, op=MPI.SUM) ** 0.5
+
     assert error_norm_global < 1e-8, f"Velocity error too high: {error_norm_global}"
-    
+
     # Cleanup
     ksp.destroy()
     A.destroy()

--- a/python/tests/test_stokes_channelflow.py
+++ b/python/tests/test_stokes_channelflow.py
@@ -145,6 +145,8 @@ def test_stokes_channelflow(cell_type, els, order):
     # Apply backsubstitution for MPCs
     mpc_u.backsubstitution(uh)
     mpc_p.backsubstitution(ph)
+    uh.x.scatter_forward()
+    ph.x.scatter_forward()
 
     # Verify solution: Poiseuille flow u_x = (dp/dx) * (1/(2*mu)) * y * (H - y)
     # For our parameters: mu=1, dp/dx=-1, H=1
@@ -158,11 +160,13 @@ def test_stokes_channelflow(cell_type, els, order):
         values[0] = 0.5 * x[1] * (1.0 - x[1])  # u_x component
         return values
 
-    u_exact = fem.Function(V)
+    u_exact = fem.Function(mpc_u.function_space)
     u_exact.interpolate(u_exact_expr)
+    u_exact.x.scatter_forward()
 
     # Compute error
     error_u = uh.x.array - u_exact.x.array
+
     error_norm = np.linalg.norm(error_u)
     error_norm_global = domain.comm.allreduce(error_norm**2, op=MPI.SUM) ** 0.5
 

--- a/python/tests/test_stokes_channelflow.py
+++ b/python/tests/test_stokes_channelflow.py
@@ -109,7 +109,7 @@ def test_stokes_channelflow(cell_type, els, order):
     ksp.setErrorIfNotConverged(True)
     ksp.setType("minres")
     rtol = 100 * np.finfo(rtype).eps
-    atol = np.finfo(rtype).eps
+    atol = 2 * np.finfo(rtype).eps
     ksp.setTolerances(rtol=rtol, atol=atol)
 
     # Setup preconditioning

--- a/python/tests/test_stokes_channelflow.py
+++ b/python/tests/test_stokes_channelflow.py
@@ -166,7 +166,7 @@ def test_stokes_channelflow(cell_type, els, order):
     error_norm = np.linalg.norm(error_u)
     error_norm_global = domain.comm.allreduce(error_norm**2, op=MPI.SUM) ** 0.5
 
-    assert error_norm_global < np.sqrt(atol), f"Velocity error too high: {error_norm_global}"
+    assert error_norm_global < np.sqrt(rtol), f"Velocity error too high: {error_norm_global}"
 
     # Cleanup
     ksp.destroy()

--- a/python/tests/test_stokes_channelflow.py
+++ b/python/tests/test_stokes_channelflow.py
@@ -8,13 +8,11 @@ from __future__ import annotations
 from mpi4py import MPI
 from petsc4py import PETSc
 
-import dolfinx.fem as fem
-import dolfinx.mesh as mesh
 import numpy as np
 import pytest
 import ufl
 from basix.ufl import element
-from dolfinx import default_scalar_type, la
+from dolfinx import default_real_type, default_scalar_type, fem, la, mesh
 from dolfinx.mesh import CellType, create_unit_cube
 
 import dolfinx_mpc
@@ -32,11 +30,12 @@ def test_stokes_channelflow(cell_type, els, order):
     """
 
     # Cube mesh
-    domain = create_unit_cube(MPI.COMM_WORLD, els, els, els, cell_type=cell_type)
+    rtype = default_real_type
+    domain = create_unit_cube(MPI.COMM_WORLD, els, els, els, cell_type=cell_type, dtype=rtype)
 
     # Function spaces: Taylor-Hood
-    V = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order, shape=(3,)))
-    Q = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order - 1))
+    V = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order, shape=(3,), dtype=rtype))
+    Q = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order - 1, dtype=rtype))
 
     # Wall BCs (top/bottom y={0,1})
     wall_facets = mesh.locate_entities_boundary(
@@ -76,8 +75,8 @@ def test_stokes_channelflow(cell_type, els, order):
 
     # Weak statement
     a00 = mu * ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
-    a01 = -ufl.div(v) * p * ufl.dx
-    a10 = -q * ufl.div(u) * ufl.dx
+    a01 = -ufl.inner(p, ufl.div(v)) * ufl.dx
+    a10 = -ufl.inner(ufl.div(u), q) * ufl.dx
     L0 = ufl.inner(f, v) * ufl.dx
     L1 = ufl.ZeroBaseForm((q,))
 
@@ -109,7 +108,9 @@ def test_stokes_channelflow(cell_type, els, order):
     ksp.setOperators(A)
     ksp.setErrorIfNotConverged(True)
     ksp.setType("minres")
-    ksp.setTolerances(rtol=1e-8, atol=1e-10)
+    rtol = 100 * np.finfo(rtype).eps
+    atol = np.finfo(rtype).eps
+    ksp.setTolerances(rtol=rtol, atol=atol)
 
     # Setup preconditioning
     pc = ksp.getPC()
@@ -165,7 +166,7 @@ def test_stokes_channelflow(cell_type, els, order):
     error_norm = np.linalg.norm(error_u)
     error_norm_global = domain.comm.allreduce(error_norm**2, op=MPI.SUM) ** 0.5
 
-    assert error_norm_global < 1e-8, f"Velocity error too high: {error_norm_global}"
+    assert error_norm_global < np.sqrt(atol), f"Velocity error too high: {error_norm_global}"
 
     # Cleanup
     ksp.destroy()

--- a/python/tests/test_stokes_channelflow.py
+++ b/python/tests/test_stokes_channelflow.py
@@ -107,6 +107,7 @@ def test_stokes_channelflow(cell_type, els, order):
     # Setup Minres solver
     ksp = PETSc.KSP().create(domain.comm)
     ksp.setOperators(A)
+    ksp.setErrorIfNotConverged(True)
     ksp.setType("minres")
     ksp.setTolerances(rtol=1e-8, atol=1e-10)
 

--- a/python/tests/test_stokes_channelflow.py
+++ b/python/tests/test_stokes_channelflow.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2026 Stein K.F. Stoter
+#
+# This file is part of DOLFINX_MPC
+#
+# SPDX-License-Identifier:    MIT
+from __future__ import annotations
+
+from mpi4py import MPI
+from petsc4py import PETSc
+
+import dolfinx.fem as fem
+import dolfinx.mesh as mesh
+import numpy as np
+import pytest
+import ufl
+from basix.ufl import element
+from dolfinx import default_scalar_type, io, la
+from dolfinx.mesh import create_unit_cube, CellType
+
+import dolfinx_mpc
+
+
+@pytest.mark.parametrize("cell_type", [CellType.tetrahedron, CellType.hexahedron])
+@pytest.mark.parametrize("els", [2, 4, 8])
+@pytest.mark.parametrize("order", [2, 3])
+def test_stokes_channelflow(cell_type, els, order):
+    """Test 3D Stokes channel flow with periodic BCs and nested assembly and Taylor-Hood elements.
+    
+    The analytical solution for Poiseuille flow between parallel plates is:
+    u_x = (dp/dx) * (1/(2*mu)) * y * (H - y)
+    where H is the channel height, dp/dx is the pressure gradient enforced as a body force, mu is viscosity.
+    """
+    
+    # Cube mesh
+    domain = create_unit_cube(MPI.COMM_WORLD, els, els, els, cell_type=cell_type)
+    
+    # Function spaces: Taylor-Hood
+    V = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order, shape=(3,)))
+    Q = fem.functionspace(domain, element("Lagrange", domain.basix_cell(), order-1))
+    
+    # Wall BCs (top/bottom y={0,1})
+    wall_facets = mesh.locate_entities_boundary(
+        domain, 2, lambda x: np.logical_or(np.isclose(x[1], 0), np.isclose(x[1], 1))
+    )
+    wall_dofs = fem.locate_dofs_topological(V, 2, wall_facets)
+    bc = fem.dirichletbc(np.zeros(3, dtype=default_scalar_type), wall_dofs, V)
+    
+    # Periodicity definition (x and z directions)
+    def periodic_boundary(x):
+        return np.logical_or(np.isclose(x[0], 1), np.isclose(x[2], 1))
+    
+    def periodic_map(x):
+        out = x.copy()
+        out[0][np.isclose(x[0], 1).nonzero()] -= 1
+        out[2][np.isclose(x[2], 1).nonzero()] -= 1
+        return out
+    
+    # Create MPCs for velocity and pressure
+    mpc_u = dolfinx_mpc.MultiPointConstraint(V)
+    mpc_u.create_periodic_constraint_geometrical(V, periodic_boundary, periodic_map, [bc])
+    mpc_u.finalize()
+    mpc_p = dolfinx_mpc.MultiPointConstraint(Q)
+    mpc_p.create_periodic_constraint_geometrical(Q, periodic_boundary, periodic_map, [])
+    mpc_p.finalize()
+    
+    # Stokes weak form
+    u = ufl.TrialFunction(V)
+    p = ufl.TrialFunction(Q)
+    v = ufl.TestFunction(V)
+    q = ufl.TestFunction(Q)
+    
+    # Viscosity and forcing
+    mu = fem.Constant(domain, default_scalar_type(1.0))
+    dp_dx = fem.Constant(domain, default_scalar_type(1.0))  # Pressure gradient in x-direction
+    f = ufl.as_vector([dp_dx, 0.0, 0.0])
+    
+    # Weak statement
+    a00 = mu * ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
+    a01 = -ufl.div(v) * p * ufl.dx
+    a10 = -q * ufl.div(u) * ufl.dx
+    L0 = ufl.inner(f, v) * ufl.dx
+    L1 = ufl.ZeroBaseForm((q,))
+    
+    forms = fem.form([[a00, a01], [a10, None]])
+    rhs_forms = fem.form([L0, L1])
+    
+    # Assemble - THIS IS WHERE THE BUG OCCURS with MPI and hexahedral cells
+    A = dolfinx_mpc.create_matrix_nest(forms, constraints=[mpc_u, mpc_p])
+    dolfinx_mpc.assemble_matrix_nest(A, forms, constraints=[mpc_u, mpc_p], bcs=[bc])
+    A.assemble()
+    
+    b = dolfinx_mpc.create_vector_nest(rhs_forms, constraints=[mpc_u, mpc_p])
+    dolfinx_mpc.assemble_vector_nest(b, rhs_forms, constraints=[mpc_u, mpc_p])
+    
+    # Apply lifting for boundary conditions
+    bcs_block = fem.bcs_by_block(fem.extract_function_spaces(forms, 1), [bc])
+    dolfinx_mpc.apply_lifting(b, forms, bcs_block, constraint=[mpc_u, mpc_p])
+    
+    # Ghost update after lifting
+    for b_sub in b.getNestSubVecs():
+        b_sub.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+    
+    # Set BC values in RHS
+    bcs0 = fem.bcs_by_block(fem.extract_function_spaces(rhs_forms), [bc])
+    fem.petsc.set_bc(b, bcs0)
+    
+    # Setup Minres solver
+    ksp = PETSc.KSP().create(domain.comm)
+    ksp.setOperators(A)
+    ksp.setType("minres")
+    ksp.setTolerances(rtol=1e-8, atol=1e-10)
+    
+    # Setup preconditioning
+    pc = ksp.getPC()
+    pc.setType("fieldsplit")
+    pc.setFieldSplitType(PETSc.PC.CompositeType.ADDITIVE)
+    nested_IS = A.getNestISs()
+    pc.setFieldSplitIS(("u", nested_IS[0][0]), ("p", nested_IS[0][1]))
+    ksp_u, ksp_p = pc.getFieldSplitSubKSP()
+    ksp_u.setType("preonly")
+    ksp_u.getPC().setType("lu")
+    ksp_u.getPC().setFactorSolverType("mumps")
+    ksp_p.setType("preonly")
+    ksp_p.getPC().setType("jacobi")
+    
+    # Finalize KSP setup
+    ksp.setFromOptions()
+    
+    # Create solution functions
+    uh = fem.Function(mpc_u.function_space)
+    ph = fem.Function(mpc_p.function_space)
+    
+    # Solve the system
+    x = b.duplicate()
+    ksp.solve(b, x)
+    la.petsc._ghost_update(
+        x,
+        insert_mode=PETSc.InsertMode.INSERT,  # type: ignore
+        scatter_mode=PETSc.ScatterMode.FORWARD,  # type: ignore
+    )  # type: ignore
+    fem.petsc.assign(x, [uh, ph])
+    
+    # Apply backsubstitution for MPCs
+    mpc_u.backsubstitution(uh)
+    mpc_p.backsubstitution(ph)
+
+    # Export solution
+    uh.name = "velocity"
+    ph.name = "pressure"
+    with io.VTXWriter(domain.comm, "/app/stokes_channelflow_u.bp", uh, engine="BP4") as vtx:
+        vtx.write(0.0)
+    with io.VTXWriter(domain.comm, "/app/stokes_channelflow_p.bp", ph, engine="BP4") as vtx:
+        vtx.write(0.0)
+
+    # Verify solution: Poiseuille flow u_x = (dp/dx) * (1/(2*mu)) * y * (H - y)
+    # For our parameters: mu=1, dp/dx=-1, H=1
+    # u_x = -(-1) * (1/2) * y * (1 - y) = 0.5 * y * (1 - y)
+    # Maximum velocity at y=0.5: u_max = 0.5 * 0.5 * 0.5 = 0.125
+    
+    # Create analytical solution function
+    def u_exact_expr(x):
+        """Exact solution for Poiseuille flow"""
+        values = np.zeros((3, x.shape[1]))
+        values[0] = 0.5 * x[1] * (1.0 - x[1])  # u_x component
+        return values
+    
+    u_exact = fem.Function(V)
+    u_exact.interpolate(u_exact_expr)
+    
+    # Compute error
+    error_u = uh.x.array - u_exact.x.array
+    error_norm = np.linalg.norm(error_u)
+    error_norm_global = domain.comm.allreduce(error_norm**2, op=MPI.SUM)**0.5
+    
+    assert error_norm_global < 1e-8, f"Velocity error too high: {error_norm_global}"
+    
+    # Cleanup
+    ksp.destroy()
+    A.destroy()
+    b.destroy()
+    x.destroy()


### PR DESCRIPTION
Progress towards #215.

Instead of the special logic for square and non-square matrices, the logic is now:
```
Loop over all cells on process
     Convert all cell dofs that are slaves into their corresponding col master dof
     Insert this for all dof rows in that cell (could be optimized by not inserting for slave rows).
     For each slave row, find the corresponding master row.
          Insert col master dofs
```
This also ensure that multiple mpcs on the different spaces are correctly handled.