### PR TITLE
add overrides to avoid invoking Python_EXECUTABLE when cross compiling

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,7 +5,7 @@ PROJECT(dolfinx_mpc_nanobind)
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
 # Detect the installed nanobind package and import it into CMake
-option(DETECT_NANOBIND_DIR "Disable if python3 -mnanobind doesn't work (e.g. cross compilation). If OFF, nanobind must be on CMAKE_PREFIX_PATH." ON)
+option(DETECT_NANOBIND_DIR "Disable if python3 -m nanobind doesn't work (e.g. cross compilation). If OFF, nanobind must be on CMAKE_PREFIX_PATH." ON)
 if (DETECT_NANOBIND_DIR)
   execute_process(
     COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,24 +2,31 @@ cmake_minimum_required(VERSION 3.21)
 
 PROJECT(dolfinx_mpc_nanobind)
 
-find_package(MPI 3 REQUIRED)
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
 # Detect the installed nanobind package and import it into CMake
-execute_process(
-  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
-  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE NB_DIR)
-list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+option(DETECT_NANOBIND_DIR "Disable if python3 -mnanobind doesn't work (e.g. cross compilation). If OFF, nanobind must be on CMAKE_PREFIX_PATH." ON)
+if (DETECT_NANOBIND_DIR)
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE NB_DIR)
+  list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+endif()
 find_package(nanobind CONFIG REQUIRED)
 
-execute_process(
-  COMMAND
-  ${Python3_EXECUTABLE} -c "import os, sys, basix; sys.stdout.write(os.path.dirname(basix.__file__))"
-  OUTPUT_VARIABLE BASIX_PY_DIR
-  RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
-  ERROR_VARIABLE BASIX_ERROR_OUT OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
+option(BASIX_HINT "Hint for finding BASIX; skips auto-detection where it might not work (cross-compiling)." "")
+if(NOT BASIX_HINT)
+  execute_process(
+    COMMAND
+    ${Python3_EXECUTABLE} -c "import os, sys, basix; sys.stdout.write(os.path.dirname(basix.__file__))"
+    OUTPUT_VARIABLE BASIX_PY_DIR
+    RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
+    ERROR_VARIABLE BASIX_ERROR_OUT OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  set(BASIX_HINT ${BASIX_PY_DIR})
+endif()
+
+find_package(Basix REQUIRED CONFIG HINTS ${BASIX_HINT})
 if (Basix_FOUND)
   message(STATUS "Found Basix at ${Basix_DIR}")
 endif()
@@ -49,33 +56,41 @@ target_compile_definitions(cpp PRIVATE cxx_std_20)
 target_link_libraries(cpp PRIVATE dolfinx_mpc)
 
 # Check for petsc4py
-execute_process(
-  COMMAND ${Python_EXECUTABLE} -c
-          "import petsc4py; print(petsc4py.get_include())"
-  OUTPUT_VARIABLE PETSC4PY_INCLUDE_DIR
-  RESULT_VARIABLE PETSC4PY_COMMAND_RESULT
-  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
-  COMMAND_ERROR_IS_FATAL ANY
-)
-
-if(NOT PETSC4PY_COMMAND_RESULT)
-  message(STATUS "Found petsc4py include directory at ${PETSC4PY_INCLUDE_DIR}")
-  target_include_directories(cpp PRIVATE ${PETSC4PY_INCLUDE_DIR})
-  target_compile_definitions(cpp PRIVATE HAS_PETSC4PY)
+option(PETSC4PY_INCLUDE_DIR "Manually set include directory for petsc4py; skips auto-detection where it might not work (cross-compiling)." "")
+if (NOT PETSC4PY_INCLUDE_DIR)
+  execute_process(
+    COMMAND ${Python_EXECUTABLE} -c
+            "import petsc4py; print(petsc4py.get_include())"
+    OUTPUT_VARIABLE PETSC4PY_INCLUDE_DIR
+    RESULT_VARIABLE PETSC4PY_COMMAND_RESULT
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+  
+  if(NOT PETSC4PY_COMMAND_RESULT)
+    message(STATUS "Found petsc4py include directory at ${PETSC4PY_INCLUDE_DIR}")
+  else()
+    message(FATAL_ERROR "petsc4py not found.")
+  endif()
 else()
-  message(FATAL_ERROR "petsc4py not found.")
+    message(STATUS "Using petsc4py include directory at ${PETSC4PY_INCLUDE_DIR}")
 endif()
-
+target_include_directories(cpp PRIVATE ${PETSC4PY_INCLUDE_DIR})
+target_compile_definitions(cpp PRIVATE HAS_PETSC4PY)
 
 
 # Get python include-dirs
-execute_process(
-  COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} ${Python3_EXECUTABLE} -c "from mpi4py import MPI; import dolfinx, sys; sys.stdout.write(str(dolfinx.get_include()))"
-  OUTPUT_VARIABLE DOLFINX_PY_DIR
-  RESULT_VARIABLE DOLFINX_PY_COMMAND_RESULT
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  COMMAND_ERROR_IS_FATAL ANY
-)
+option(DOLFINX_PY_DIR "Include directory for dolfinx python wrappers; skips auto-detection where it might not work (cross-compiling)." "")
+if (NOT DOLFINX_PY_DIR)
+  find_package(MPI 3 REQUIRED)
+  execute_process(
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} ${Python3_EXECUTABLE} -c "from mpi4py import MPI; import dolfinx, sys; sys.stdout.write(str(dolfinx.get_include()))"
+    OUTPUT_VARIABLE DOLFINX_PY_DIR
+    RESULT_VARIABLE DOLFINX_PY_COMMAND_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+endif()
 
 if (DOLFINX_PY_DIR)
   message(STATUS "Adding ${DOLFINX_PY_DIR} to include directories")


### PR DESCRIPTION
closes #232 

when using cross-python, most of the python imports actually work, but specifically the mpiexec added in #224 does not.

In general, it's a good practice to allow anything that you detect by execution in the host environment to be overrideable by explicit variable, since those often don't work when cross compiling.